### PR TITLE
fix(ci): use working iOS custom-build defaults

### DIFF
--- a/.github/workflows/ios-custom-build.yml
+++ b/.github/workflows/ios-custom-build.yml
@@ -22,7 +22,7 @@ on:
       injiFlavor:
         description: 'Select Inji flavor'
         required: true
-        default: 'inji'
+        default: 'residentapp'
         type: choice
         options:
           - residentapp
@@ -33,7 +33,7 @@ on:
       internal-testers:
         description: 'Internal Testers Group'
         required: true
-        default: 'QA'
+        default: 'Dev-testing'
         type: choice
         options:
           - Dev-testing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS custom build workflow defaults to use the Resident App flavor and Dev-testing distribution channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->