### PR TITLE
update workflows to use tagged version of kattu and skip sonar job

### DIFF
--- a/.github/workflows/android-custom-build.yml
+++ b/.github/workflows/android-custom-build.yml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   build-android:
-    uses: mosip/kattu/.github/workflows/android-build.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/android-build.yml@v0.0.1
     with:
         NODE_VERSION: '18.x'
         JAVA_VERSION: '17'

--- a/.github/workflows/clear_artifacts.yml
+++ b/.github/workflows/clear_artifacts.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   delete-artifacts:
-    uses: mosip/kattu/.github/workflows/clear-artifacts.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/clear-artifacts.yml@v0.0.1
     secrets:
       ACCESS_TOKEN: ${{ secrets.ACTION_PAT }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}

--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -93,7 +93,7 @@ jobs:
   build-android:
     if: ${{ inputs.buildFor == 'Both[Android and IOS]' || inputs.buildFor == 'Android'}}
     needs: set-client-id
-    uses: mosip/kattu/.github/workflows/android-publish.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/android-publish.yml@v0.0.1
     with:
       RELEASE: ${{ inputs.release }}
       NODE_VERSION: '18.x'
@@ -121,7 +121,7 @@ jobs:
 
   build-android-beta:
     if: ${{ inputs.release == 'beta' && (inputs.buildFor == 'Both[Android and IOS]' || inputs.buildFor == 'Android') }}
-    uses: mosip/kattu/.github/workflows/android-publish.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/android-publish.yml@v0.0.1
     with:
       RELEASE: ${{ inputs.release }}
       NODE_VERSION: '18.x'
@@ -149,7 +149,7 @@ jobs:
 
   build-ios:
     if: ${{ inputs.buildFor == 'Both[Android and IOS]' || inputs.buildFor == 'IOS'}}
-    uses: mosip/kattu/.github/workflows/ios-publish.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/ios-publish.yml@v0.0.1
     with:
       NODE_VERSION: '18.x'
       MIMOTO_HOST: ${{ inputs.mimotoBackendServiceUrl }}

--- a/.github/workflows/ios-custom-build.yml
+++ b/.github/workflows/ios-custom-build.yml
@@ -60,7 +60,7 @@ on:
 
 jobs:
   build-ios:
-    uses: mosip/kattu/.github/workflows/ios-publish.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/ios-publish.yml@v0.0.1
     with:
       NODE_VERSION: '18.x'
       MIMOTO_HOST: ${{ inputs.mimotoBackendServiceUrl }}

--- a/.github/workflows/push-triggers.yml
+++ b/.github/workflows/push-triggers.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-android:
-    uses: mosip/kattu/.github/workflows/android-build.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/android-build.yml@v0.0.1
     with:
       NODE_VERSION: "18.x"
       JAVA_VERSION: "17"
@@ -32,7 +32,7 @@ jobs:
       UPLOAD_TO_ACTIONS: 'false'
 
   build-ios:
-    uses: mosip/kattu/.github/workflows/ios-build.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/ios-build.yml@v0.0.1
     with:
       NODE_VERSION: "18.x"
       SERVICE_LOCATION: '.'
@@ -59,19 +59,19 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
         if: failure()
 
-  sonar-check-on-push:
-    name: Sonar check
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: [build-android, build-ios, run-tests]
-    uses: mosip/kattu/.github/workflows/npm-sonar-analysis.yml@develop
-    with:
-      SERVICE_LOCATION: '.'
-      NODE_VERSION: '18.x'
-      SONAR_SOURCES: 'routes,screens,machines,lib/jsonld-signatures,components,shared'
-      SONAR_TESTS: 'routes,screens,machines,lib/jsonld-signatures,components,shared'
-      SONAR_TEST_INCLUSIONS: '**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.spec.jsx,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/__tests__/**'
-      SONAR_EXCLUSIONS: '**/node_modules/**,**/android/**,**/ios/**,**/build/**,**/dist/**,**/*.java,**/__mocks__/**,**/__snapshots__/**,**/*.snap,**/*.d.ts,**/*.typegen.ts,**/interfaces/**,**/test-config/**,**/jestGlobalMocks.ts,**/index.js'
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      ORG_KEY: ${{ secrets.ORG_KEY }}
-      SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}'
+#  sonar-check-on-push:
+#    name: Sonar check
+#    if: ${{ github.event_name != 'pull_request' }}
+#    needs: [build-android, build-ios, run-tests]
+#    uses: mosip/kattu/.github/workflows/npm-sonar-analysis.yml@develop
+#    with:
+#      SERVICE_LOCATION: '.'
+#      NODE_VERSION: '18.x'
+#      SONAR_SOURCES: 'routes,screens,machines,lib/jsonld-signatures,components,shared'
+#      SONAR_TESTS: 'routes,screens,machines,lib/jsonld-signatures,components,shared'
+#      SONAR_TEST_INCLUSIONS: '**/*.spec.ts,**/*.spec.tsx,**/*.spec.js,**/*.spec.jsx,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/__tests__/**'
+#      SONAR_EXCLUSIONS: '**/node_modules/**,**/android/**,**/ios/**,**/build/**,**/dist/**,**/*.java,**/__mocks__/**,**/__snapshots__/**,**/*.snap,**/*.d.ts,**/*.typegen.ts,**/interfaces/**,**/test-config/**,**/jestGlobalMocks.ts,**/index.js'
+#    secrets:
+#      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#      ORG_KEY: ${{ secrets.ORG_KEY }}
+#      SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   tag-branch:
-    uses: mosip/kattu/.github/workflows/tag.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/tag.yaml@v0.0.1
     with:
       TAG: ${{ inputs.TAG }}
       BODY: ${{ inputs.BODY }}


### PR DESCRIPTION
update kattu tag and commented sonar job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android and iOS build workflows to use the stable `v0.0.1` release.
  * Updated artifact cleanup automation to use the stable workflow release.
  * Disabled Sonar analysis for push-triggered builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->