### PR TITLE
chore: update inji dependencies to tagged 1.0.0-alpha.1 versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -273,20 +273,18 @@ dependencies {
     implementation 'com.facebook.soloader:soloader:0.10.1+'
     implementation("com.google.code.gson:gson:2.10.1")
 
-    implementation("io.inji:injivcrenderer-aar:1.0.0-alpha.1-SNAPSHOT")
-    implementation("io.inji:inji-openid4vp-aar:1.0.0-alpha.1-SNAPSHOT"){
-        changing = true
+    implementation("io.inji:injivcrenderer-aar:1.0.0-alpha.1")
+    implementation("io.inji:inji-openid4vp-aar:1.0.0-alpha.1"){
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk18on'
         exclude group: 'io.inji', module: 'vcverifier-jar'
         exclude group: 'com.google.crypto.tink', module: 'tink'
         exclude group: 'com.augustcellars.cose', module:'cose-java'
     }
-    implementation("io.inji:pixelpass-aar:1.0.0-alpha.1-SNAPSHOT")
-    implementation("io.inji:secure-keystore:1.0.0-alpha.1-SNAPSHOT")
-    implementation("io.inji:tuvali:1.0.0-alpha.1-SNAPSHOT")
-    implementation("io.inji:inji-vci-client-aar:1.0.0-alpha.1-SNAPSHOT"){
-        changing = true
+    implementation("io.inji:pixelpass-aar:1.0.0-alpha.1")
+    implementation("io.inji:secure-keystore:1.0.0-alpha.1")
+    implementation("io.inji:tuvali:1.0.0-alpha.1")
+    implementation("io.inji:inji-vci-client-aar:1.0.0-alpha.1"){
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk18on'
         exclude group: 'io.inji', module: 'vcverifier-jar'

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1158,48 +1158,48 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/pixelpass-ios-swift/";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 		9CCC57752E9D7C7000669DB7 /* XCRemoteSwiftPackageReference "tuvali-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/tuvali-ios-swift/";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 		9CCCA19C2CF87A8400D5A461 /* XCRemoteSwiftPackageReference "secure-keystore-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/secure-keystore-ios-swift";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 		C33922392E79A536004A01EC /* XCRemoteSwiftPackageReference "inji-vc-renderer-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/inji-vc-renderer-ios-swift.git";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 		E641C9E42FEAE9C9002D18A7 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 		E6728B4D2FF7E2C40068A964 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift";
 			requirement = {
-				branch = "release-1.0.x";
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.0-alpha.1";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "f6b514860e271a279888468cb24536ae2d51c685"
+        "revision" : "e61b22dcac557f80f097a1bd32299f1c165d2c25",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/inji-vc-renderer-ios-swift.git",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "9f4b7911c1112185518e14ef43507a10fa5ff6ea"
+        "revision" : "335f132abfe78630a6c827adc443d3d8b6982431",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "a5db2dcee43955136f63e658a6e53a76a1364b21"
+        "revision" : "492e159eec445dab625ba78aa5f3c74a30297924",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/pixelpass-ios-swift/",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "c52ad3d13f056489ceaa6d291a5395353f18491e"
+        "revision" : "0f6223ef65012260d93ec4a2273ca9f14be2a2a5",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/secure-keystore-ios-swift",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "4ac90b96a35eabb81b6eb091875498a9fd1f75be"
+        "revision" : "19defe6f77dcc1ed5daa65ddf38be8370027f8d5",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/tuvali-ios-swift/",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "775e8358d4a1a84cbb841d164c2a0ba4cb6a3433"
+        "revision" : "6d9d9e8b74086f03bbec76671c684c2830cbb0e3",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {


### PR DESCRIPTION
Moves Android deps off SNAPSHOT and iOS SPM deps off branch-tracking, onto the published `1.0.0-alpha.1` release.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Android and iOS platform components to their latest stable release versions.
  * Improved consistency across supported mobile platforms.
  * Removed reliance on pre-release development builds, helping provide a more reliable app experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->