### PR TITLE
redirect to redirect_uri post VP submission if available

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -659,4 +659,7 @@ fileignoreconfig:
 - filename: ios/Inji/Info.plist
   allowed_patterns:
   - LSApplicationQueriesSchemes
+- filename: ios/BrowserRedirect.swift
+  allowed_patterns:
+  - ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -653,4 +653,10 @@ fileignoreconfig:
 - filename: screens/Issuers/__snapshots__/TransactionCodeScreen.test.tsx.snap
   allowed_patterns:
   - keyboardShouldPersistTaps
+- filename: components/openid4vp/BrowserSelectionModal.tsx
+  allowed_patterns:
+  - key={browser.id}
+- filename: ios/Inji/Info.plist
+  allowed_patterns:
+  - LSApplicationQueriesSchemes
 version: "1.0"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,11 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
     <application
         android:name=".MainApplication"

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -36,6 +37,8 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.WalletConfig;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult;
+import io.mosip.openID4VP.browser.BrowserApp;
+import io.mosip.openID4VP.browser.BrowserRedirectHandler;
 import io.mosip.openID4VP.dcql.evaluator.MatchingCredentialsResult;
 import io.mosip.openID4VP.dcql.query.DCQLQuery;
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
@@ -145,6 +148,44 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
             promise.resolve(verifierResponseJson);
         } catch (Exception e) {
             rejectWithOpenID4VPExceptions(e, promise);
+        }
+    }
+
+    @ReactMethod
+    public void getAvailableBrowsers(Promise promise) {
+        try {
+            WritableArray browsers = Arguments.createArray();
+            for (BrowserApp browser : new BrowserRedirectHandler(getReactApplicationContext()).getAvailableBrowsers()) {
+                WritableMap browserMap = Arguments.createMap();
+                browserMap.putString("id", browser.getPackageName());
+                browserMap.putString("displayName", browser.getDisplayName());
+                browserMap.putBoolean("isDefault", browser.isDefault());
+                browsers.pushMap(browserMap);
+            }
+            promise.resolve(browsers);
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to list the browsers installed on the device - " + e.getMessage());
+            promise.resolve(Arguments.createArray());
+        }
+    }
+
+    @ReactMethod
+    public void redirectToVerifier(String redirectUri, @Nullable String browserId, Promise promise) {
+        try {
+            BrowserRedirectHandler redirectHandler = new BrowserRedirectHandler(getReactApplicationContext());
+            BrowserApp selectedBrowser = null;
+            if (browserId != null && !browserId.isEmpty()) {
+                for (BrowserApp browser : redirectHandler.getAvailableBrowsers()) {
+                    if (browser.getPackageName().equals(browserId)) {
+                        selectedBrowser = browser;
+                        break;
+                    }
+                }
+            }
+            promise.resolve(redirectHandler.redirect(redirectUri, selectedBrowser));
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to redirect to the redirect_uri returned by the Verifier - " + e.getMessage());
+            promise.resolve(false);
         }
     }
 

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -5,6 +5,11 @@ import static io.mosip.residentapp.utils.OpenId4VPUtils.parseVPTokenSigningResul
 import static io.mosip.residentapp.utils.OpenId4VPUtils.parseWalletConfig;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.os.Build;
 import android.util.Base64;
 import android.util.Log;
 
@@ -28,8 +33,18 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import io.mosip.openID4VP.OpenID4VP;
 import io.mosip.openID4VP.authorizationRequest.AuthorizationDcqlRequest;
@@ -37,8 +52,6 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.WalletConfig;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult;
-import io.mosip.openID4VP.browser.BrowserApp;
-import io.mosip.openID4VP.browser.BrowserRedirectHandler;
 import io.mosip.openID4VP.dcql.evaluator.MatchingCredentialsResult;
 import io.mosip.openID4VP.dcql.query.DCQLQuery;
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
@@ -51,6 +64,8 @@ import io.mosip.residentapp.utils.OpenId4VPUtils;
 public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
     private static final String TAG = "InjiOpenID4VPModule";
     private static final String MODULE_NAME = "InjiOpenID4VP";
+    private static final Set<String> BROWSER_SCHEMES = new HashSet<>(Arrays.asList("http", "https"));
+    private static final int MAX_PORT = 65535;
 
     private OpenID4VP openID4VP;
     private Gson gson;
@@ -155,11 +170,11 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
     public void getAvailableBrowsers(Promise promise) {
         try {
             WritableArray browsers = Arguments.createArray();
-            for (BrowserApp browser : new BrowserRedirectHandler(getReactApplicationContext()).getAvailableBrowsers()) {
+            for (InstalledBrowser browser : availableBrowsers()) {
                 WritableMap browserMap = Arguments.createMap();
-                browserMap.putString("id", browser.getPackageName());
-                browserMap.putString("displayName", browser.getDisplayName());
-                browserMap.putBoolean("isDefault", browser.isDefault());
+                browserMap.putString("id", browser.packageName);
+                browserMap.putString("displayName", browser.displayName);
+                browserMap.putBoolean("isDefault", browser.isDefault);
                 browsers.pushMap(browserMap);
             }
             promise.resolve(browsers);
@@ -172,20 +187,189 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void redirectToVerifier(String redirectUri, @Nullable String browserId, Promise promise) {
         try {
-            BrowserRedirectHandler redirectHandler = new BrowserRedirectHandler(getReactApplicationContext());
-            BrowserApp selectedBrowser = null;
-            if (browserId != null && !browserId.isEmpty()) {
-                for (BrowserApp browser : redirectHandler.getAvailableBrowsers()) {
-                    if (browser.getPackageName().equals(browserId)) {
+            String sanitizedRedirectUri = sanitizeRedirectUri(redirectUri);
+            if (sanitizedRedirectUri == null) {
+                Log.e(TAG, "Verifier returned a redirect_uri that is not an absolute navigable URI. Redirection is skipped.");
+                promise.resolve(false);
+                return;
+            }
+
+            boolean browserNavigable = isBrowserNavigableRedirectUri(sanitizedRedirectUri);
+            InstalledBrowser selectedBrowser = null;
+            if (browserNavigable && browserId != null && !browserId.isEmpty()) {
+                for (InstalledBrowser browser : availableBrowsers()) {
+                    if (browser.packageName.equals(browserId)) {
                         selectedBrowser = browser;
                         break;
                     }
                 }
             }
-            promise.resolve(redirectHandler.redirect(redirectUri, selectedBrowser));
+
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(sanitizedRedirectUri));
+            if (browserNavigable) {
+                intent.addCategory(Intent.CATEGORY_BROWSABLE);
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (selectedBrowser != null) {
+                intent.setClassName(selectedBrowser.packageName, selectedBrowser.activityName);
+            }
+
+            getReactApplicationContext().startActivity(intent);
+            promise.resolve(true);
         } catch (Exception e) {
             Log.e(TAG, "Unable to redirect to the redirect_uri returned by the Verifier - " + e.getMessage());
             promise.resolve(false);
+        }
+    }
+
+    private static final class InstalledBrowser {
+        final String packageName;
+        final String activityName;
+        final String displayName;
+        final boolean isDefault;
+
+        InstalledBrowser(String packageName, String activityName, String displayName, boolean isDefault) {
+            this.packageName = packageName;
+            this.activityName = activityName;
+            this.displayName = displayName;
+            this.isDefault = isDefault;
+        }
+    }
+
+    private List<InstalledBrowser> availableBrowsers() {
+        PackageManager packageManager = getReactApplicationContext().getPackageManager();
+        if (packageManager == null) {
+            return Collections.emptyList();
+        }
+
+        Intent probeIntent = new Intent()
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE)
+                .setData(Uri.fromParts("http", "", null));
+
+        String defaultBrowserPackage = null;
+        try {
+            ResolveInfo defaultBrowser = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    ? packageManager.resolveActivity(probeIntent, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY))
+                    : packageManager.resolveActivity(probeIntent, PackageManager.MATCH_DEFAULT_ONLY);
+            if (defaultBrowser != null && defaultBrowser.activityInfo != null) {
+                defaultBrowserPackage = defaultBrowser.activityInfo.packageName;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to resolve the default browser - " + e.getMessage());
+        }
+
+        List<ResolveInfo> resolveInfos;
+        try {
+            resolveInfos = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    ? packageManager.queryIntentActivities(probeIntent, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_ALL))
+                    : packageManager.queryIntentActivities(probeIntent, PackageManager.MATCH_ALL);
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to query the browsers installed on the device - " + e.getMessage());
+            return Collections.emptyList();
+        }
+
+        Map<String, InstalledBrowser> browsersByPackage = new LinkedHashMap<>();
+        for (ResolveInfo resolveInfo : resolveInfos) {
+            if (resolveInfo.activityInfo == null) {
+                continue;
+            }
+            String packageName = resolveInfo.activityInfo.packageName;
+            if (browsersByPackage.containsKey(packageName)) {
+                continue;
+            }
+
+            String displayName = packageName;
+            try {
+                CharSequence label = resolveInfo.loadLabel(packageManager);
+                if (label != null && label.toString().trim().length() > 0) {
+                    displayName = label.toString();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Unable to read the label of " + packageName + " - " + e.getMessage());
+            }
+
+            browsersByPackage.put(packageName, new InstalledBrowser(
+                    packageName,
+                    resolveInfo.activityInfo.name,
+                    displayName,
+                    packageName.equals(defaultBrowserPackage)));
+        }
+
+        List<InstalledBrowser> browsers = new ArrayList<>(browsersByPackage.values());
+        Collections.sort(browsers, new Comparator<InstalledBrowser>() {
+            @Override
+            public int compare(InstalledBrowser first, InstalledBrowser second) {
+                if (first.isDefault != second.isDefault) {
+                    return first.isDefault ? -1 : 1;
+                }
+                return first.displayName.toLowerCase(Locale.ROOT)
+                        .compareTo(second.displayName.toLowerCase(Locale.ROOT));
+            }
+        });
+        return browsers;
+    }
+
+    @Nullable
+    private static String sanitizeRedirectUri(@Nullable String redirectUri) {
+        if (redirectUri == null) {
+            return null;
+        }
+        String value = redirectUri.trim();
+        if (value.isEmpty()) {
+            return null;
+        }
+
+        URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+
+        String scheme = uri.getScheme() == null ? null : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!uri.isAbsolute() || scheme == null || scheme.isEmpty()) {
+            return null;
+        }
+        if (BROWSER_SCHEMES.contains(scheme) && !hasNavigableHost(uri)) {
+            return null;
+        }
+        return value;
+    }
+
+    private static boolean hasNavigableHost(URI uri) {
+        String host = uri.getHost();
+        if (host != null && !host.trim().isEmpty()) {
+            return uri.getPort() <= MAX_PORT;
+        }
+
+        String authority = uri.getAuthority();
+        if (authority == null) {
+            return false;
+        }
+        int userInfoSeparator = authority.indexOf('@');
+        String hostAndPort = userInfoSeparator >= 0 ? authority.substring(userInfoSeparator + 1) : authority;
+        int portSeparator = hostAndPort.lastIndexOf(':');
+        if (portSeparator < 0) {
+            return !hostAndPort.trim().isEmpty();
+        }
+
+        String hostPart = hostAndPort.substring(0, portSeparator);
+        int port;
+        try {
+            port = Integer.parseInt(hostAndPort.substring(portSeparator + 1));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return !hostPart.trim().isEmpty() && port >= 0 && port <= MAX_PORT;
+    }
+
+    private static boolean isBrowserNavigableRedirectUri(String sanitizedRedirectUri) {
+        try {
+            String scheme = new URI(sanitizedRedirectUri).getScheme();
+            return scheme != null && BROWSER_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT));
+        } catch (URISyntaxException e) {
+            return false;
         }
     }
 

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -338,18 +338,24 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
     }
 
     private static boolean hasNavigableHost(URI uri) {
-        String host = uri.getHost();
-        if (host != null && !host.trim().isEmpty()) {
-            return uri.getPort() <= MAX_PORT;
-        }
-
-        String authority = uri.getAuthority();
+        String authority = uri.getRawAuthority();
         if (authority == null) {
             return false;
         }
-        int userInfoSeparator = authority.indexOf('@');
+        int userInfoSeparator = authority.lastIndexOf('@');
         String hostAndPort = userInfoSeparator >= 0 ? authority.substring(userInfoSeparator + 1) : authority;
-        int portSeparator = hostAndPort.lastIndexOf(':');
+
+        int portSeparator;
+        if (hostAndPort.startsWith("[")) {
+            int closingBracket = hostAndPort.indexOf(']');
+            if (closingBracket < 0) {
+                return false;
+            }
+            portSeparator = hostAndPort.indexOf(':', closingBracket + 1);
+        } else {
+            portSeparator = hostAndPort.lastIndexOf(':');
+        }
+
         if (portSeparator < 0) {
             return !hostAndPort.trim().isEmpty();
         }

--- a/components/openid4vp/BrowserSelectionModal.tsx
+++ b/components/openid4vp/BrowserSelectionModal.tsx
@@ -16,14 +16,19 @@ export const BrowserSelectionModal: React.FC<
   const {redirectUri, onRedirectHandled} = props;
 
   const redirectTo = async (browserId?: string) => {
+    let redirected = false;
     try {
-      await OpenID4VP.redirectToVerifier(redirectUri, browserId);
+      redirected = await OpenID4VP.redirectToVerifier(redirectUri, browserId);
     } catch (error) {
       console.warn('Error during redirection:', error);
-    } finally {
-      setBrowsers([]);
-      onRedirectHandled();
     }
+
+    if (!redirected && browsers.length > 1) {
+      return;
+    }
+
+    setBrowsers([]);
+    onRedirectHandled();
   };
 
   useEffect(() => {

--- a/components/openid4vp/BrowserSelectionModal.tsx
+++ b/components/openid4vp/BrowserSelectionModal.tsx
@@ -1,0 +1,127 @@
+import React, {useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Modal, Pressable, View} from 'react-native';
+import {Button, Column, Row, Text} from '../ui';
+import {Theme} from '../ui/styleUtils';
+import testIDProps from '../../shared/commonUtil';
+import OpenID4VP from '../../shared/openID4VP/OpenID4VP';
+import {AvailableBrowser} from '../../shared/openID4VP/openid4vp.types';
+
+export const BrowserSelectionModal: React.FC<
+  BrowserSelectionModalProps
+> = props => {
+  const {t} = useTranslation('ScanScreen');
+  const [browsers, setBrowsers] = useState<AvailableBrowser[]>([]);
+
+  const {redirectUri, onRedirectHandled} = props;
+
+  const redirectTo = async (browserId?: string) => {
+    try {
+      await OpenID4VP.redirectToVerifier(redirectUri, browserId);
+    } catch (error) {
+      console.warn('Error during redirection:', error);
+    } finally {
+      setBrowsers([]);
+      onRedirectHandled();
+    }
+  };
+
+  useEffect(() => {
+    if (!redirectUri) {
+      setBrowsers([]);
+      return;
+    }
+
+    let isActive = true;
+
+    const resolveBrowsers = async () => {
+      const availableBrowsers = await OpenID4VP.getAvailableBrowsers();
+      if (!isActive) return;
+
+      if (availableBrowsers.length > 1) {
+        setBrowsers(availableBrowsers);
+        return;
+      }
+
+      await redirectTo(availableBrowsers[0]?.id);
+    };
+
+    void resolveBrowsers();
+
+    return () => {
+      isActive = false;
+    };
+  }, [redirectUri]);
+
+  return (
+    <Modal
+      visible={browsers.length > 1}
+      transparent
+      animationType="fade"
+      onRequestClose={() => redirectTo(undefined)}
+      {...testIDProps('browserSelectionModal')}>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        }}>
+        <Column
+          margin="24"
+          padding="24"
+          backgroundColor={Theme.Colors.whiteBackgroundColor}
+          style={{borderRadius: 12}}>
+          <Text
+            testID="browserSelectionTitle"
+            margin="0 0 8 0"
+            style={Theme.TextStyles.bold}
+            size={'large'}>
+            {t('status.browserSelection.title')}
+          </Text>
+          <Text
+            testID="browserSelectionMessage"
+            margin="0 0 20 0"
+            style={Theme.TextStyles.regular}
+            color={Theme.Colors.statusMessage}>
+            {t('status.browserSelection.message')}
+          </Text>
+
+          {browsers.map(browser => (
+            <Pressable
+              key={browser.id}
+              testID={`browserOption-${browser.id}`}
+              onPress={() => redirectTo(browser.id)}>
+              <Row align="space-between" crossAlign="center" margin="0 0 16 0">
+                <Text style={Theme.TextStyles.regular}>
+                  {browser.displayName}
+                </Text>
+                {browser.isDefault && (
+                  <Text
+                    style={Theme.TextStyles.regular}
+                    color={Theme.Colors.statusMessage}>
+                    {t('status.browserSelection.defaultBrowser')}
+                  </Text>
+                )}
+              </Row>
+            </Pressable>
+          ))}
+
+          <Button
+            testID="browserSelectionSkipButton"
+            type="clear"
+            title={t('status.browserSelection.skip')}
+            onPress={() => {
+              setBrowsers([]);
+              onRedirectHandled();
+            }}
+          />
+        </Column>
+      </View>
+    </Modal>
+  );
+};
+
+interface BrowserSelectionModalProps {
+  redirectUri: string;
+  onRedirectHandled: () => void;
+}

--- a/ios/BrowserRedirect.swift
+++ b/ios/BrowserRedirect.swift
@@ -1,0 +1,207 @@
+import Foundation
+import UIKit
+
+struct BrowserApp: Identifiable, Equatable {
+    let id: String
+    let displayName: String
+    let isDefault: Bool
+    let probeURL: URL?
+    let redirectURLBuilder: RedirectURLBuilder
+
+    static func == (lhs: BrowserApp, rhs: BrowserApp) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    func redirectURL(for redirectUri: String) -> URL? {
+        guard let url = sanitizeRedirectUri(redirectUri).flatMap({ URL(string: $0) }) else {
+            return nil
+        }
+        return redirectURLBuilder.build(from: url)
+    }
+}
+
+enum RedirectURLBuilder {
+    case systemDefault
+    case replaceScheme(http: String, https: String)
+    case percentEncodedQuery(prefix: String)
+    case schemeless(prefix: String)
+
+    func build(from url: URL) -> URL? {
+        switch self {
+        case .systemDefault:
+            return url
+
+        case let .replaceScheme(httpReplacement, httpsReplacement):
+            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let scheme = components.scheme?.lowercased()
+            else { return nil }
+
+            switch scheme {
+            case "http": components.scheme = httpReplacement
+            case "https": components.scheme = httpsReplacement
+            default: return nil
+            }
+            return components.url
+
+        case let .percentEncodedQuery(prefix):
+            guard let encoded = url.absoluteString
+                .addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved)
+            else { return nil }
+            return URL(string: prefix + encoded)
+
+        case let .schemeless(prefix):
+            guard let scheme = url.scheme else { return nil }
+            let schemeless = String(url.absoluteString.dropFirst("\(scheme)://".count))
+            guard !schemeless.isEmpty else { return nil }
+            return URL(string: prefix + schemeless)
+        }
+    }
+}
+
+extension BrowserApp {
+    static let systemDefault = BrowserApp(
+        id: "default",
+        displayName: "Default browser",
+        isDefault: true,
+        probeURL: nil,
+        redirectURLBuilder: .systemDefault
+    )
+
+    static let chrome = BrowserApp(
+        id: "chrome",
+        displayName: "Chrome",
+        isDefault: false,
+        probeURL: URL(string: "googlechromes://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "googlechrome", https: "googlechromes")
+    )
+
+    static let firefox = BrowserApp(
+        id: "firefox",
+        displayName: "Firefox",
+        isDefault: false,
+        probeURL: URL(string: "firefox://open-url?url=https%3A%2F%2Fverifier.example.com"),
+        redirectURLBuilder: .percentEncodedQuery(prefix: "firefox://open-url?url=")
+    )
+
+    static let edge = BrowserApp(
+        id: "edge",
+        displayName: "Edge",
+        isDefault: false,
+        probeURL: URL(string: "microsoft-edge-https://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "microsoft-edge-http", https: "microsoft-edge-https")
+    )
+
+    static let brave = BrowserApp(
+        id: "brave",
+        displayName: "Brave",
+        isDefault: false,
+        probeURL: URL(string: "brave://open-url?url=https%3A%2F%2Fverifier.example.com"),
+        redirectURLBuilder: .percentEncodedQuery(prefix: "brave://open-url?url=")
+    )
+
+    static let opera = BrowserApp(
+        id: "opera",
+        displayName: "Opera Touch",
+        isDefault: false,
+        probeURL: URL(string: "touch-https://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "touch-http", https: "touch-https")
+    )
+
+    static let duckDuckGo = BrowserApp(
+        id: "duckduckgo",
+        displayName: "DuckDuckGo",
+        isDefault: false,
+        probeURL: URL(string: "ddgQuickLink://verifier.example.com"),
+        redirectURLBuilder: .schemeless(prefix: "ddgQuickLink://")
+    )
+
+    static let knownBrowsers: [BrowserApp] = [chrome, firefox, edge, brave, opera, duckDuckGo]
+}
+
+final class BrowserRedirectHandler {
+
+    func getAvailableBrowsers() async -> [BrowserApp] {
+        var availableBrowsers: [BrowserApp] = [.systemDefault]
+
+        for browser in BrowserApp.knownBrowsers {
+            guard let probeURL = browser.probeURL else { continue }
+            if await canOpen(probeURL) {
+                availableBrowsers.append(browser)
+            }
+        }
+
+        return availableBrowsers
+    }
+
+    @discardableResult
+    func redirect(redirectUri: String?, using browser: BrowserApp? = nil) async -> Bool {
+        guard let sanitizedRedirectUri = sanitizeRedirectUri(redirectUri) else {
+            return false
+        }
+
+        let selectedBrowser = isBrowserNavigableRedirectUri(sanitizedRedirectUri)
+            ? (browser ?? .systemDefault)
+            : .systemDefault
+
+        guard let redirectURL = selectedBrowser.redirectURL(for: sanitizedRedirectUri) else {
+            return false
+        }
+
+        return await open(redirectURL)
+    }
+
+    private func canOpen(_ url: URL) async -> Bool {
+        return await MainActor.run { UIApplication.shared.canOpenURL(url) }
+    }
+
+    private func open(_ url: URL) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                UIApplication.shared.open(url, options: [:]) { opened in
+                    continuation.resume(returning: opened)
+                }
+            }
+        }
+    }
+}
+
+private let browserSchemes: Set<String> = ["http", "https"]
+
+private let rfc3986UriCharacters = CharacterSet(
+    charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        + "-._~:/?#[]@!$&'()*+,;=%"
+)
+
+private func containsOnlyRfc3986Characters(_ value: String) -> Bool {
+    return value.unicodeScalars.allSatisfy { rfc3986UriCharacters.contains($0) }
+}
+
+private func sanitizeRedirectUri(_ redirectUri: String?) -> String? {
+    guard let value = redirectUri?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty,
+          containsOnlyRfc3986Characters(value),
+          let components = URLComponents(string: value),
+          let scheme = components.scheme?.lowercased(),
+          !scheme.isEmpty,
+          URL(string: value) != nil
+    else { return nil }
+
+    if browserSchemes.contains(scheme), (components.host ?? "").isEmpty {
+        return nil
+    }
+
+    return value
+}
+
+private func isBrowserNavigableRedirectUri(_ redirectUri: String?) -> Bool {
+    guard let value = sanitizeRedirectUri(redirectUri),
+          let scheme = URLComponents(string: value)?.scheme?.lowercased()
+    else { return false }
+    return browserSchemes.contains(scheme)
+}
+
+private extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+}

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1E6875EB2CA554FD0086D870 /* RNOpenID4VPModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E6875EA2CA554FD0086D870 /* RNOpenID4VPModule.m */; };
 		1E6875ED2CA5550F0086D870 /* RNOpenID4VPModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6875EC2CA5550F0086D870 /* RNOpenID4VPModule.swift */; };
 		1EED69F92DA913D30042EAFC /* IntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EED69F82DA913D30042EAFC /* IntentData.swift */; };
+		BE5246430000000000000001 /* BrowserRedirect.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5246430000000000000002 /* BrowserRedirect.swift */; };
 		1EED69FD2DA914D00042EAFC /* RNDeepLinkIntentModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EED69FC2DA914D00042EAFC /* RNDeepLinkIntentModule.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		61450CD968A57153077CB5A9 /* libPods-Inji.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 433CCC1AA8055E18ADC2C596 /* libPods-Inji.a */; };
@@ -106,6 +107,7 @@
 		1E6875EA2CA554FD0086D870 /* RNOpenID4VPModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNOpenID4VPModule.m; sourceTree = "<group>"; };
 		1E6875EC2CA5550F0086D870 /* RNOpenID4VPModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNOpenID4VPModule.swift; sourceTree = "<group>"; };
 		1EED69F82DA913D30042EAFC /* IntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentData.swift; sourceTree = "<group>"; };
+		BE5246430000000000000002 /* BrowserRedirect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserRedirect.swift; sourceTree = "<group>"; };
 		1EED69FA2DA914130042EAFC /* RNDeepLinkIntentModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNDeepLinkIntentModule.swift; sourceTree = "<group>"; };
 		1EED69FC2DA914D00042EAFC /* RNDeepLinkIntentModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNDeepLinkIntentModule.m; sourceTree = "<group>"; };
 		433CCC1AA8055E18ADC2C596 /* libPods-Inji.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Inji.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -232,6 +234,7 @@
 				1E6875EC2CA5550F0086D870 /* RNOpenID4VPModule.swift */,
 				1D23B9CD47CFD7F3C87D202F /* PrivacyInfo.xcprivacy */,
 				1EED69F82DA913D30042EAFC /* IntentData.swift */,
+				BE5246430000000000000002 /* BrowserRedirect.swift */,
 				1EED69FA2DA914130042EAFC /* RNDeepLinkIntentModule.swift */,
 				1EED69FC2DA914D00042EAFC /* RNDeepLinkIntentModule.m */,
 			);
@@ -885,6 +888,7 @@
 				9C48504B2C3E59B5002ECBD5 /* RNWalletModule.swift in Sources */,
 				E6D946EE2EFAA332004DA688 /* VciBridge.swift in Sources */,
 				1EED69F92DA913D30042EAFC /* IntentData.swift in Sources */,
+				BE5246430000000000000001 /* BrowserRedirect.swift in Sources */,
 				9C48504D2C3E59B5002ECBD5 /* RNWalletModule.m in Sources */,
 				9C3BD83C2EA8D63A00101656 /* CredentialsVerifierFactory.swift in Sources */,
 				9C3BD83D2EA8D63A00101656 /* VerifiableCredential.swift in Sources */,

--- a/ios/Inji/Info.plist
+++ b/ios/Inji/Info.plist
@@ -114,6 +114,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechrome</string>
+		<string>googlechromes</string>
+		<string>firefox</string>
+		<string>microsoft-edge-http</string>
+		<string>microsoft-edge-https</string>
+		<string>brave</string>
+		<string>touch-http</string>
+		<string>touch-https</string>
+		<string>ddgQuickLink</string>
+	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>

--- a/ios/RNOpenID4VPModule.m
+++ b/ios/RNOpenID4VPModule.m
@@ -40,6 +40,14 @@ RCT_EXTERN_METHOD(sendErrorToVerifier:(NSString *)error
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getAvailableBrowsers:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(redirectToVerifier:(NSString *)redirectUri
+                  :(NSString *)browserId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(requiresMainQueueSetup:(BOOL))
 
 @end

--- a/ios/RNOpenID4VPModule.swift
+++ b/ios/RNOpenID4VPModule.swift
@@ -211,6 +211,36 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
     }
   }
   
+  @objc
+  func getAvailableBrowsers(_ resolve: @escaping RCTPromiseResolveBlock,
+                            rejecter reject: @escaping RCTPromiseRejectBlock) {
+    Task {
+      let browsers = await BrowserRedirectHandler().getAvailableBrowsers()
+      resolve(browsers.map { browser in
+        [
+          "id": browser.id,
+          "displayName": browser.displayName,
+          "isDefault": browser.isDefault
+        ]
+      })
+    }
+  }
+
+  @objc
+  func redirectToVerifier(_ redirectUri: String, _ browserId: String?,
+                          resolver resolve: @escaping RCTPromiseResolveBlock,
+                          rejecter reject: @escaping RCTPromiseRejectBlock) {
+    Task {
+      let redirectHandler = BrowserRedirectHandler()
+      var selectedBrowser: BrowserApp?
+      if let browserId, !browserId.isEmpty {
+        selectedBrowser = await redirectHandler.getAvailableBrowsers()
+          .first { $0.id == browserId }
+      }
+      resolve(await redirectHandler.redirect(redirectUri: redirectUri, using: selectedBrowser))
+    }
+  }
+
   private func parseVerifiers(_ verifiers: [[String: Any]]) throws -> [Verifier] {
     return try verifiers.map { verifierDict in
       

--- a/locales/en.json
+++ b/locales/en.json
@@ -1008,6 +1008,12 @@
           "title": "An Error Occured!",
           "message": "Something went wrong while transferring the card. Please try again."
         }
+      },
+      "browserSelection": {
+        "title": "Open with",
+        "message": "The Verifier asked to continue in a browser. Choose a browser to open.",
+        "skip": "Skip",
+        "defaultBrowser": "Default"
       }
     },
     "postFaceCapture": {
@@ -1172,7 +1178,7 @@
       "previous": "Previous",
       "next": "Next",
       "instruction": "Select a card from each step to continue"
-  },
+    },
     "verifierInfo": {
       "trusted": "Trusted",
       "unknownVerifier": "Unknown Verifier"
@@ -1306,22 +1312,17 @@
   "common": {
     "card": "card",
     "cards": "cards",
-
     "goHome": "Home",
-
     "accept": "Accept",
     "save": "Save",
     "ok": "OK",
-
     "cancel": "Cancel",
     "dismiss": "Dismiss",
     "goBack": "Go Back",
     "back": "Back",
     "ignore": "Ignore",
     "decline": "Decline",
-
     "tryAgain": "Try again",
-
     "editLabel": "Edit {{label}}",
     "camera": {
       "errors": {

--- a/machines/openID4VP/openID4VPActions.test.ts
+++ b/machines/openID4VP/openID4VPActions.test.ts
@@ -134,6 +134,25 @@ describe('openID4VPActions', () => {
   });
 
   describe('assignment callbacks', () => {
+    it('setPendingRedirectUri stores the redirect_uri returned by the Verifier', () => {
+      const fn = actions.setPendingRedirectUri.assignment.pendingRedirectUri;
+      expect(
+        fn({}, {data: {redirect_uri: 'https://verifier.example.com/cb'}}),
+      ).toBe('https://verifier.example.com/cb');
+    });
+
+    it('setPendingRedirectUri stores an empty value when there is no redirect_uri', () => {
+      const fn = actions.setPendingRedirectUri.assignment.pendingRedirectUri;
+      expect(fn({}, {data: {}})).toBe('');
+      expect(fn({}, {})).toBe('');
+      expect(fn({}, {data: {redirect_uri: 42}})).toBe('');
+    });
+
+    it('resetPendingRedirectUri clears the stored redirect_uri', () => {
+      const fn = actions.resetPendingRedirectUri.assignment.pendingRedirectUri;
+      expect(fn()).toBe('');
+    });
+
     it('setPresentationRequest sets presentationRequest from event', () => {
       const fn = actions.setPresentationRequest.assignment.presentationRequest;
       expect(fn({}, {presentationRequest: 'req-data'})).toBe('req-data');

--- a/machines/openID4VP/openID4VPActions.ts
+++ b/machines/openID4VP/openID4VPActions.ts
@@ -20,7 +20,6 @@ import {
 } from '../../shared/openID4VP/openid4vp.types';
 import OpenID4VP from '../../shared/openID4VP/OpenID4VP';
 import {isDcqlFlow} from '../../shared/openID4VP/OpenID4VPHelper';
-import {openURL} from '../../shared/browserUtils';
 
 // TODO - get this presentation definition list which are alias for scope param
 // from the verifier end point after the endpoint is created and exposed.
@@ -303,20 +302,15 @@ export const openID4VPActions = (model: any) => {
       availableWalletCredentials: (_, event) => event.vcs,
     }),
 
-    redirectToVerifier: async (_, event) => {
-      const redirectUri = event?.data?.redirect_uri;
+    setPendingRedirectUri: model.assign({
+      pendingRedirectUri: (_, event: any) => {
+        const redirectUri = event?.data?.redirect_uri;
+        return typeof redirectUri === 'string' ? redirectUri : '';
+      },
+    }),
 
-      if (!redirectUri || typeof redirectUri !== 'string') {
-        return;
-      }
-
-      try {
-        new URL(redirectUri);
-        await openURL(redirectUri);
-      } catch (error) {
-        console.warn('Error during redirection:', error);
-        return;
-      }
-    },
+    resetPendingRedirectUri: model.assign({
+      pendingRedirectUri: () => '',
+    }),
   };
 };

--- a/machines/openID4VP/openID4VPMachine.ts
+++ b/machines/openID4VP/openID4VPMachine.ts
@@ -548,7 +548,7 @@ export const openID4VPMachine = model.createMachine(
                       logType: 'SHARED_WITH_FACE_VERIFIACTION',
                     }),
                     sendParent('SUCCESS'),
-                    'redirectToVerifier',
+                    'setPendingRedirectUri',
                   ],
                   target: '#success',
                 },
@@ -559,7 +559,7 @@ export const openID4VPMachine = model.createMachine(
                       logType: 'SHARED_SUCCESSFULLY',
                     }),
                     sendParent('SUCCESS'),
-                    'redirectToVerifier',
+                    'setPendingRedirectUri',
                   ],
                   target: '#success',
                 },
@@ -629,6 +629,11 @@ export const openID4VPMachine = model.createMachine(
       },
       success: {
         id: 'success',
+        on: {
+          REDIRECT_HANDLED: {
+            actions: 'resetPendingRedirectUri',
+          },
+        },
       },
       authFlowFailed: {
         entry: [

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -193,6 +193,7 @@ export interface Typegen0 {
       | 'error.platform.OpenID4VP.getTrustedVerifiersList:invocation[0]'
       | 'xstate.stop';
     resetOpenID4VPRetryCount: 'RESET_RETRY_COUNT';
+    resetPendingRedirectUri: 'REDIRECT_HANDLED';
     setAuthenticationError: 'error.platform.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponse: 'done.invoke.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponseForPresentationAuthFlow: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
@@ -206,6 +207,7 @@ export interface Typegen0 {
     setIsShareWithSelfie: 'AUTHENTICATE';
     setIsShowLoadingScreen: 'AUTHENTICATE' | 'AUTHENTICATE_VIA_PRESENTATION';
     setMiniViewShareSelectedVC: 'AUTHENTICATE';
+    setPendingRedirectUri: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     setPresentationRequest: 'AUTHENTICATE_VIA_PRESENTATION';
     setSelectedVCs: 'ACCEPT_REQUEST' | 'VERIFY_AND_ACCEPT_REQUEST';
     setSendVPShareError: 'error.platform.OpenID4VP.sendingVP.sendVP:invocation[0]';

--- a/machines/openID4VP/openID4VPModel.ts
+++ b/machines/openID4VP/openID4VPModel.ts
@@ -42,6 +42,7 @@ const openID4VPEvents = {
   FACE_INVALID: () => ({}),
   DISMISS: () => ({}),
   DISMISS_POPUP: () => ({}),
+  REDIRECT_HANDLED: () => ({}),
   RETRY_VERIFICATION: () => ({}),
   STORE_RESPONSE: (response: any) => ({response}),
   GO_BACK: () => ({}),
@@ -92,6 +93,7 @@ export const openID4VPModel = createModel(
     unsignedVPToken: {} as object,
     hasNoMatchingVCs: false as boolean,
     availableWalletCredentials: [] as VC[],
+    pendingRedirectUri: '' as string,
   },
   {events: openID4VPEvents},
 );

--- a/machines/openID4VP/openID4VPSelectors.ts
+++ b/machines/openID4VP/openID4VPSelectors.ts
@@ -158,3 +158,7 @@ export function selectVerifierLogoInTrustModal(state: State) {
 export function selectIsAuthorization(state: State) {
   return state.context.flowType === VCShareFlowType.OPENID4VP_AUTHORIZATION;
 }
+
+export function selectPendingRedirectUri(state: State) {
+  return state.context.pendingRedirectUri;
+}

--- a/screens/openid4vp/SendVPScreen.tsx
+++ b/screens/openid4vp/SendVPScreen.tsx
@@ -39,6 +39,7 @@ import {SendVPActions} from '../../components/openid4vp/SendVPActions';
 import {SendVPOverlays} from '../../components/openid4vp/overlay/SendVPOverlays';
 import {SendVPError} from '../../components/openid4vp/SendVPError';
 import {DeeplinkBanner} from '../../components/DeeplinkBanner';
+import {BrowserSelectionModal} from '../../components/openid4vp/BrowserSelectionModal';
 
 export const SendVPScreen: React.FC<ScanLayoutProps> = props => {
   const {t} = useTranslation('SendVPScreen');
@@ -230,6 +231,10 @@ export const SendVPScreen: React.FC<ScanLayoutProps> = props => {
   return (
     <React.Fragment>
       <DeeplinkBanner absolute />
+      <BrowserSelectionModal
+        redirectUri={controller.pendingRedirectUri}
+        onRedirectHandled={controller.REDIRECT_HANDLED}
+      />
       {
         <TrustModalVerifier
           isVisible={controller.showTrustConsentModal}

--- a/screens/openid4vp/SendVPScreenController.ts
+++ b/screens/openid4vp/SendVPScreenController.ts
@@ -5,7 +5,10 @@ import {useTranslation} from 'react-i18next';
 import {Theme} from '../../components/ui/styleUtils';
 import {selectIsCancelling} from '../../machines/bleShare/commonSelectors';
 import {ScanEvents} from '../../machines/bleShare/scan/scanMachine';
-import {selectFlowType, selectIsSendingVPError,} from '../../machines/bleShare/scan/scanSelectors';
+import {
+  selectFlowType,
+  selectIsSendingVPError,
+} from '../../machines/bleShare/scan/scanSelectors';
 import {
   selectAreAllVCsChecked,
   selectCredentials,
@@ -17,6 +20,7 @@ import {
   selectIsInvalidIdentity,
   selectIsOVPViaDeeplink,
   selectIsSelectingVcs,
+  selectPendingRedirectUri,
   selectIsSharingVP,
   selectIsShowError,
   selectIsShowLoadingScreen,
@@ -45,8 +49,8 @@ import {VPShareOverlayProps} from '../Scan/VPShareOverlay';
 import {ActivityLogEvents} from '../../machines/activityLog';
 import {VPShareActivityLog} from '../../components/VPShareActivityLogEvent';
 import {isIOS} from '../../shared/constants';
-import {getFaceAttribute,} from '../../components/VC/common/VCUtils';
-import {VC,} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
+import {getFaceAttribute} from '../../components/VC/common/VCUtils';
+import {VC} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 import {isDcqlFlow} from '../../shared/openID4VP/OpenID4VPHelper';
 
 type MyVcsTabNavigation = NavigationProp<RootRouteProps>;
@@ -121,6 +125,10 @@ export function useSendVPScreen(props) {
   const showConfirmationPopup = useSelector(
     openID4VPService,
     selectShowConfirmationPopup,
+  );
+  const pendingRedirectUri = useSelector(
+    openID4VPService,
+    selectPendingRedirectUri,
   );
   const isSelectingVCs = useSelector(openID4VPService, selectIsSelectingVcs);
   const error = useSelector(openID4VPService, selectIsError);
@@ -328,5 +336,8 @@ export function useSendVPScreen(props) {
     openID4VPRetryCount,
     RESET_RETRY_COUNT: () =>
       openID4VPService.send(OpenID4VPEvents.RESET_RETRY_COUNT()),
+    pendingRedirectUri,
+    REDIRECT_HANDLED: () =>
+      openID4VPService.send(OpenID4VPEvents.REDIRECT_HANDLED()),
   };
 }

--- a/shared/openID4VP/OpenID4VP.test.ts
+++ b/shared/openID4VP/OpenID4VP.test.ts
@@ -23,6 +23,8 @@ const mockAuthenticateVerifier = jest.fn();
 const mockConstructUnsignedVPToken = jest.fn();
 const mockShareVerifiablePresentation = jest.fn();
 const mockSendErrorToVerifier = jest.fn();
+const mockGetAvailableBrowsers = jest.fn();
+const mockRedirectToVerifier = jest.fn();
 const mockGetMatchingCredentials = jest.fn();
 const mockSendJsonLdCanonicalizeResultFromJS = jest.fn();
 const mockSendJsonLdExpandResultFromJS = jest.fn();
@@ -38,6 +40,8 @@ const mockAddListener = jest.fn(
 
 type MockInjiOpenID4VP = {
   getMatchingCredentials: jest.Mock;
+  getAvailableBrowsers: jest.Mock;
+  redirectToVerifier: jest.Mock;
   sendJsonLdCanonicalizeResultFromJS: jest.Mock;
   sendJsonLdExpandResultFromJS: jest.Mock;
   notifyCanonicalizationFailureFromJS: jest.Mock;
@@ -64,6 +68,8 @@ jest.mock('react-native', () => {
         constructUnsignedVPToken: mockConstructUnsignedVPToken,
         shareVerifiablePresentation: mockShareVerifiablePresentation,
         sendErrorToVerifier: mockSendErrorToVerifier,
+        getAvailableBrowsers: mockGetAvailableBrowsers,
+        redirectToVerifier: mockRedirectToVerifier,
         getMatchingCredentials: mockGetMatchingCredentials,
         sendJsonLdCanonicalizeResultFromJS:
           mockSendJsonLdCanonicalizeResultFromJS,
@@ -237,6 +243,8 @@ describe('OpenID4VP', () => {
     mockSendJsonLdCanonicalizeResultFromJS.mockClear();
     mockSendJsonLdExpandResultFromJS.mockClear();
     mockNotifyCanonicalizationFailureFromJS.mockClear();
+    mockGetAvailableBrowsers.mockReset();
+    mockRedirectToVerifier.mockReset();
     // Don't clear  mockAddListener to preserve its implementation
     mockedGetWalletConfig.mockClear();
     mockedJsonLdCanonicalize.mockClear();
@@ -263,6 +271,8 @@ describe('OpenID4VP', () => {
       mockSendJsonLdExpandResultFromJS;
     nativeModule.notifyCanonicalizationFailureFromJS =
       mockNotifyCanonicalizationFailureFromJS;
+    nativeModule.getAvailableBrowsers = mockGetAvailableBrowsers;
+    nativeModule.redirectToVerifier = mockRedirectToVerifier;
 
     mockedGetWalletConfig.mockResolvedValue(null);
     mockedGetWalletConfig.mockResolvedValue({
@@ -390,6 +400,62 @@ describe('OpenID4VP', () => {
       expect(nativeModule.sendErrorToVerifier).toHaveBeenCalledWith(
         'error msg',
         'ERR_001',
+      );
+    });
+  });
+
+  describe('getAvailableBrowsers', () => {
+    it('should return the browsers reported by the native module', async () => {
+      const nativeModule = getOpenID4VPNativeModule();
+      const browsers = [
+        {id: 'com.android.chrome', displayName: 'Chrome', isDefault: true},
+      ];
+      nativeModule.getAvailableBrowsers.mockResolvedValue(browsers);
+
+      expect(await OpenID4VP.getAvailableBrowsers()).toEqual(browsers);
+    });
+
+    it('should return an empty list when the native module fails', async () => {
+      const nativeModule = getOpenID4VPNativeModule();
+      nativeModule.getAvailableBrowsers.mockRejectedValue(new Error('boom'));
+
+      expect(await OpenID4VP.getAvailableBrowsers()).toEqual([]);
+    });
+
+    it('should return an empty list when the native module returns nothing', async () => {
+      const nativeModule = getOpenID4VPNativeModule();
+      nativeModule.getAvailableBrowsers.mockResolvedValue(undefined);
+
+      expect(await OpenID4VP.getAvailableBrowsers()).toEqual([]);
+    });
+  });
+
+  describe('redirectToVerifier', () => {
+    it('should redirect using the browser chosen by the end user', async () => {
+      const nativeModule = getOpenID4VPNativeModule();
+      nativeModule.redirectToVerifier.mockResolvedValue(true);
+
+      const redirected = await OpenID4VP.redirectToVerifier(
+        'https://verifier.example.com/cb',
+        'com.android.chrome',
+      );
+
+      expect(nativeModule.redirectToVerifier).toHaveBeenCalledWith(
+        'https://verifier.example.com/cb',
+        'com.android.chrome',
+      );
+      expect(redirected).toBe(true);
+    });
+
+    it('should let the platform resolve a handler when no browser is chosen', async () => {
+      const nativeModule = getOpenID4VPNativeModule();
+      nativeModule.redirectToVerifier.mockResolvedValue(true);
+
+      await OpenID4VP.redirectToVerifier('https://verifier.example.com/cb');
+
+      expect(nativeModule.redirectToVerifier).toHaveBeenCalledWith(
+        'https://verifier.example.com/cb',
+        '',
       );
     });
   });

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -20,6 +20,7 @@ import {
 import {isIOS} from '../constants';
 import {getDisclosuresForPath} from '../claimsPathMatching';
 import {
+  AvailableBrowser,
   CredentialSetOption,
   MatchingVcsResult,
   MatchingVCsResultForDcql,
@@ -235,6 +236,31 @@ class OpenID4VP {
     const openID4VP = await OpenID4VP.getInstance();
 
     return openID4VP.InjiOpenID4VP.sendErrorToVerifier(errorMessage, errorCode);
+  }
+
+  static async getAvailableBrowsers(): Promise<AvailableBrowser[]> {
+    try {
+      const openID4VP = await OpenID4VP.getInstance();
+      return (await openID4VP.InjiOpenID4VP.getAvailableBrowsers()) ?? [];
+    } catch (error) {
+      console.warn(
+        'Unable to list the browsers available on the device:',
+        error,
+      );
+      return [];
+    }
+  }
+
+  static async redirectToVerifier(
+    redirectUri: string,
+    browserId?: string,
+  ): Promise<boolean> {
+    const openID4VP = await OpenID4VP.getInstance();
+
+    return await openID4VP.InjiOpenID4VP.redirectToVerifier(
+      redirectUri,
+      browserId ?? '',
+    );
   }
 
   static async sendCanonicalizedData(data: string) {

--- a/shared/openID4VP/openid4vp.types.ts
+++ b/shared/openID4VP/openid4vp.types.ts
@@ -1,4 +1,4 @@
-import {VCMetadata} from "../VCMetadata";
+import {VCMetadata} from '../VCMetadata';
 
 export interface UnsignedVPToken {
   id: string;
@@ -16,6 +16,12 @@ export interface VerifierInfo {
 export interface VPTokenSigningResult {
   id: string;
   signedData: string;
+}
+
+export interface AvailableBrowser {
+  id: string;
+  displayName: string;
+  isDefault: boolean;
 }
 
 export type MatchingVcsResult =
@@ -61,11 +67,11 @@ export interface Claim {
 }
 
 export class VCInfo {
-  vcKey: string
-  metadata: VCMetadata
+  vcKey: string;
+  metadata: VCMetadata;
 
   constructor(vcKey: string, metadata: VCMetadata) {
-    this.vcKey = vcKey
-    this.metadata = metadata
+    this.vcKey = vcKey;
+    this.metadata = metadata;
   }
 }


### PR DESCRIPTION
## Description
> - Bridges getAvailableBrowsers and redirectToVerifier through both native modules — InjiOpenID4VPModule.java and RNOpenID4VPModule.swift/.m.
>- Adds BrowserSelectionModal, mounted on SendVPScreen; it auto-redirects when only one browser exists and prompts otherwise.
>- Replaces the machine's direct redirect with pendingRedirectUri state plus a REDIRECT_HANDLED event, so the UI owns browser choice.
>- Declares nine browser schemes in ios/Inji/Info.plist; without them canOpenURL always returns false and iOS would silently show one browser.
> - Conformance oid4vp-1final-wallet-alternate-happy-flow PASSED on Android — 80 successes, zero failures, redirect verified as a real browser GET with the fragment intact.

## Attaching screen shot of conformance suite  for reference

<img width="1923" height="868" alt="Screenshot from 2026-08-18 13-40-02" src="https://github.com/user-attachments/assets/c5a0a69d-423e-47be-a6c0-d540b6fd50b8" />

<img width="1923" height="868" alt="image" src="https://github.com/user-attachments/assets/a82b12dd-e2f7-4d60-b838-2108a5137610" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added browser selection when redirecting to OpenID4VP verifiers.
- Automatically uses the available or default browser when appropriate.
- Supports choosing from installed browsers, skipping, or closing the selection prompt.
- Added support for common browsers on Android and iOS, with localized selection messages.

## Bug Fixes
- Improved handling of missing, invalid, or failed verifier redirects.

## Tests
- Added coverage for browser discovery, browser-specific redirects, fallback behavior, and redirect state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->