### PR TITLE
   Fix: Use minWidth for copilot tour guide buttons to prevent alignment issues

### DIFF
--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -437,7 +437,7 @@ export const DefaultTheme = {
       resizeMode: 'contain',
       aspectRatio: 1,
       height: 35,
-      marginRight: 10
+      marginRight: 10,
     },
     vcDetailsLogo: {
       height: 65,
@@ -765,9 +765,10 @@ export const DefaultTheme = {
       minHeight: Dimensions.get('screen').height * COPILOT_HEIGHT,
     },
     copilotButton: {
-      width: 104,
+      minWidth: 104,
       height: 40,
       marginLeft: 10,
+      paddingHorizontal: 12,
     },
     copilotButtonsContainer: {
       marginTop: 25,

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -440,7 +440,7 @@ export const PurpleTheme = {
       resizeMode: 'contain',
       aspectRatio: 1,
       height: 35,
-      marginRight: 10
+      marginRight: 10,
     },
     vcDetailsLogo: {
       height: 65,
@@ -773,9 +773,10 @@ export const PurpleTheme = {
       minHeight: Dimensions.get('screen').height * COPILOT_HEIGHT,
     },
     copilotButton: {
-      width: 104,
+      minWidth: 104,
       height: 40,
       marginLeft: 10,
+      paddingHorizontal: 12,
     },
     copilotButtonsContainer: {
       marginTop: 25,


### PR DESCRIPTION
The Tour guide tooltip buttons (Previous/Next/Done) use a hardcoded `width: 104` in both DefaultTheme.ts and PurpleTheme.ts. This can cause text clipping/misalignment for longer button labels or different font-scaling settings across devices.

This PR changes `width` to `minWidth` and adds `paddingHorizontal` so the button sizes to its content while maintaining a sensible minimum size.

Testing -
Tested on Android 16 device with default and increased system font size, and on a smaller-screen device could not reproduce the original reported issue on this Android version, but the fix is a more robust/defensive approach regardless.

Related to #2490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button sizing and spacing for a more flexible, consistent appearance across default and purple themes.
  * Updated issuer logo styling for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->