### PR TITLE
build(android): update targetSdk to 36

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,7 +16,7 @@ import {
 } from './machines/app';
 import {DualMessageOverlay} from './components/DualMessageOverlay';
 import {useApp} from './screens/AppController';
-import {Alert, AppState, Platform} from 'react-native';
+import {Alert, AppState} from 'react-native';
 import {
   configureTelemetry,
   getErrorEventData,
@@ -32,6 +32,7 @@ import {CopilotTooltip} from './components/CopilotTooltip';
 import {Theme} from './components/ui/styleUtils';
 import {selectAppSetupComplete} from './machines/auth';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
+import {isAndroidVersionBelow} from './shared/constants';
 
 const {RNSecureKeystoreModule} = NativeModules;
 // kludge: this is a bad practice but has been done temporarily to surface
@@ -170,9 +171,7 @@ export default function App() {
       <GlobalContextProvider>
         <CopilotProvider
           stopOnOutsideClick
-          androidStatusBarVisible={
-            Platform.OS === 'android' && Platform.Version < 35
-          }
+          androidStatusBarVisible={isAndroidVersionBelow(35)}
           tooltipComponent={CopilotTooltip}
           tooltipStyle={Theme.Styles.copilotStyle}
           stepNumberComponent={() => null}

--- a/App.tsx
+++ b/App.tsx
@@ -16,7 +16,7 @@ import {
 } from './machines/app';
 import {DualMessageOverlay} from './components/DualMessageOverlay';
 import {useApp} from './screens/AppController';
-import {Alert, AppState} from 'react-native';
+import {Alert, AppState, Platform} from 'react-native';
 import {
   configureTelemetry,
   getErrorEventData,
@@ -31,6 +31,7 @@ import {CopilotProvider} from 'react-native-copilot';
 import {CopilotTooltip} from './components/CopilotTooltip';
 import {Theme} from './components/ui/styleUtils';
 import {selectAppSetupComplete} from './machines/auth';
+import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 
 const {RNSecureKeystoreModule} = NativeModules;
 // kludge: this is a bad practice but has been done temporarily to surface
@@ -59,7 +60,8 @@ const AppLayoutWrapper: React.FC = () => {
   const authService = appService.children.get('auth');
   const isAppSetupComplete = useSelector(authService, selectAppSetupComplete);
 
-  const [isDeepLinkOverlayVisible, setDeepLinkOverlayVisible] = useState(isDeepLinkFlow);
+  const [isDeepLinkOverlayVisible, setDeepLinkOverlayVisible] =
+    useState(isDeepLinkFlow);
 
   useEffect(() => {
     if (AppState.currentState === 'active') {
@@ -164,16 +166,22 @@ const AppInitialization: React.FC = () => {
 
 export default function App() {
   return (
-    <GlobalContextProvider>
-      <CopilotProvider
-        stopOnOutsideClick
-        androidStatusBarVisible
-        tooltipComponent={CopilotTooltip}
-        tooltipStyle={Theme.Styles.copilotStyle}
-        stepNumberComponent={() => null}
-        animated>
-        <AppInitialization />
-      </CopilotProvider>
-    </GlobalContextProvider>
+    <SafeAreaProvider>
+      <GlobalContextProvider>
+        <CopilotProvider
+          stopOnOutsideClick
+          androidStatusBarVisible={
+            Platform.OS === 'android' && Platform.Version < 35
+          }
+          tooltipComponent={CopilotTooltip}
+          tooltipStyle={Theme.Styles.copilotStyle}
+          stepNumberComponent={() => null}
+          animated>
+          <SafeAreaView style={{flex: 1}} edges={['bottom']}>
+            <AppInitialization />
+          </SafeAreaView>
+        </CopilotProvider>
+      </GlobalContextProvider>
+    </SafeAreaProvider>
   );
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,8 +40,12 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="false"
         android:usesCleartextTraffic="false"
         tools:replace="usesCleartextTraffic">
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
         <meta-data
             android:name="expo.modules.updates.ENABLED"
             android:value="true" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
-        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "21.4.7075529"
+        compileSdkVersion = 36
+        targetSdkVersion = 36
+        ndkVersion = "27.0.12077973"
         kotlinVersion = "1.9.22"
     }
     repositories {
@@ -16,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.4.0")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+networkTimeout=60000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/components/HelpScreen.tsx
+++ b/components/HelpScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {FlatList, Linking, Pressable, SafeAreaView, View} from 'react-native';
+import {FlatList, Linking, Pressable, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import {Modal} from './ui/Modal';
 import {Column, Text} from './ui';
 import {Theme} from './ui/styleUtils';

--- a/components/__snapshots__/HelpScreen.test.tsx.snap
+++ b/components/__snapshots__/HelpScreen.test.tsx.snap
@@ -37,7 +37,15 @@ exports[`HelpScreen Component should match snapshot when disabled 1`] = `
       Help
     </Text>
   </View>,
-  <RCTSafeAreaView
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "additive",
+      }
+    }
     style={
       {
         "flex": 1,
@@ -1636,7 +1644,7 @@ exports[`HelpScreen Component should match snapshot when disabled 1`] = `
         </View>
       </RCTScrollView>
     </View>
-  </RCTSafeAreaView>,
+  </RNCSafeAreaView>,
 ]
 `;
 
@@ -1677,7 +1685,15 @@ exports[`HelpScreen Component should match snapshot with BackUp source 1`] = `
       Help
     </Text>
   </View>,
-  <RCTSafeAreaView
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "additive",
+      }
+    }
     style={
       {
         "flex": 1,
@@ -3276,7 +3292,7 @@ exports[`HelpScreen Component should match snapshot with BackUp source 1`] = `
         </View>
       </RCTScrollView>
     </View>
-  </RCTSafeAreaView>,
+  </RNCSafeAreaView>,
 ]
 `;
 
@@ -3317,7 +3333,15 @@ exports[`HelpScreen Component should match snapshot with Inji source 1`] = `
       Help
     </Text>
   </View>,
-  <RCTSafeAreaView
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "additive",
+      }
+    }
     style={
       {
         "flex": 1,
@@ -4916,7 +4940,7 @@ exports[`HelpScreen Component should match snapshot with Inji source 1`] = `
         </View>
       </RCTScrollView>
     </View>
-  </RCTSafeAreaView>,
+  </RNCSafeAreaView>,
 ]
 `;
 
@@ -4957,7 +4981,15 @@ exports[`HelpScreen Component should match snapshot with keyManagement source 1`
       Help
     </Text>
   </View>,
-  <RCTSafeAreaView
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "additive",
+        "left": "additive",
+        "right": "additive",
+        "top": "additive",
+      }
+    }
     style={
       {
         "flex": 1,
@@ -6556,6 +6588,6 @@ exports[`HelpScreen Component should match snapshot with keyManagement source 1`
         </View>
       </RCTScrollView>
     </View>
-  </RCTSafeAreaView>,
+  </RNCSafeAreaView>,
 ]
 `;

--- a/components/ui/Error.test.tsx
+++ b/components/ui/Error.test.tsx
@@ -56,6 +56,7 @@ jest.mock('../../shared/constants', () => ({
 }));
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({top: 0, bottom: 0, left: 0, right: 0}),
+  SafeAreaView: ({children}: {children: React.ReactNode}) => children,
 }));
 
 import {ErrorView} from './Error';

--- a/components/ui/Error.tsx
+++ b/components/ui/Error.tsx
@@ -259,11 +259,13 @@ export const ErrorView: React.FC<ErrorProps> = props => {
         backgroundColor: Theme.Colors.whiteBackgroundColor,
       }}
       {...testIDProps(testID)}>
-      <Column fill safe>
+      <Column
+        fill
+        safe
+        safeEdges={goBack ? ['left', 'right'] : ['top', 'left', 'right']}>
         {goBack && <Header testID="errorHeader" goBack={goBack} />}
         <Column
           fill
-          safe
           align={alignActionsOnEnd ? 'flex-start' : 'space-evenly'}>
           {errorContent()}
         </Column>

--- a/components/ui/Header.test.tsx
+++ b/components/ui/Header.test.tsx
@@ -4,6 +4,7 @@ import {Header} from './Header';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({top: 44, bottom: 34, left: 0, right: 0}),
+  SafeAreaView: 'RCTSafeAreaView',
 }));
 
 describe('Header', () => {

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -9,7 +9,11 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 export const Header: React.FC<HeaderProps> = ({goBack, title, testID}) => {
   const insets = useSafeAreaInsets();
   return (
-    <Column safe align="center" testID={testID}>
+    <Column
+      safe
+      safeEdges={['left', 'right']}
+      align="center"
+      testID={testID}>
       <Row elevation={2}>
         <View
           style={{

--- a/components/ui/Layout.tsx
+++ b/components/ui/Layout.tsx
@@ -7,8 +7,8 @@ import {
   StyleSheet,
   ScrollView,
   RefreshControlProps,
-  SafeAreaView,
 } from 'react-native';
+import {SafeAreaView, type Edges} from 'react-native-safe-area-context';
 import {Theme, ElevationLevel, Spacing} from './styleUtils';
 import testIDProps from '../../shared/commonUtil';
 
@@ -45,19 +45,24 @@ function createLayout(
       props.pX ? {paddingHorizontal: props.pX} : null,
     ];
 
-    const ViewType = props.safe ? SafeAreaView : View;
-
     return props.scroll ? (
-        <ScrollView
-          {...testIDProps(props.testID)}
-          contentContainerStyle={styles}
-          refreshControl={props.refreshControl}>
-          {props.children}
-        </ScrollView>
-    ) : (
-      <ViewType {...testIDProps(props.testID)} style={styles}>
+      <ScrollView
+        {...testIDProps(props.testID)}
+        contentContainerStyle={styles}
+        refreshControl={props.refreshControl}>
         {props.children}
-      </ViewType>
+      </ScrollView>
+    ) : props.safe ? (
+      <SafeAreaView
+        {...testIDProps(props.testID)}
+        style={styles}
+        edges={props.safeEdges}>
+        {props.children}
+      </SafeAreaView>
+    ) : (
+      <View {...testIDProps(props.testID)} style={styles}>
+        {props.children}
+      </View>
     );
   };
 
@@ -93,5 +98,6 @@ interface LayoutProps {
   pY?: number | string | undefined;
   pX?: number | string | undefined;
   safe?: boolean;
+  safeEdges?: Edges;
   children: React.ReactNode;
 }

--- a/components/ui/Loader.tsx
+++ b/components/ui/Loader.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment, useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
-import {BackHandler, SafeAreaView, View} from 'react-native';
+import {BackHandler, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import {Button, Centered, Column, Row, Text} from '../../components/ui';
 import {Theme} from './styleUtils';
 import {LoaderAnimation} from './LoaderAnimation';
@@ -115,7 +116,9 @@ export const Loader: React.FC<LoaderProps> = ({
       ) : (
         <Fragment>
           <Row>
-            <SafeAreaView style={Theme.ModalStyles.header}>
+            <SafeAreaView
+              style={Theme.ModalStyles.header}
+              edges={['top']}>
               <Row
                 fill
                 align={'flex-start'}

--- a/components/ui/__snapshots__/Header.test.tsx.snap
+++ b/components/ui/__snapshots__/Header.test.tsx.snap
@@ -4,6 +4,12 @@ exports[`Header should render with title 1`] = `
 <RCTSafeAreaView
   accessibilityLabel="header"
   accessible={true}
+  edges={
+    [
+      "left",
+      "right",
+    ]
+  }
   style={
     [
       {
@@ -199,6 +205,12 @@ exports[`Header should render without title 1`] = `
 <RCTSafeAreaView
   accessibilityLabel="header"
   accessible={true}
+  edges={
+    [
+      "left",
+      "right",
+    ]
+  }
   style={
     [
       {

--- a/components/ui/processingScreen/ProcessingModal.tsx
+++ b/components/ui/processingScreen/ProcessingModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {SafeAreaView, View} from 'react-native';
+import {View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import FastImage from 'react-native-fast-image';
 import {Text} from '../Text';
 import {Modal} from '../Modal';

--- a/patches/@react-native+gradle-plugin+0.74.87.patch
+++ b/patches/@react-native+gradle-plugin+0.74.87.patch
@@ -1,0 +1,35 @@
+diff --git a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/build.gradle.kts b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+index 5c9ddc1..00f1da7 100644
+--- a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
++++ b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+@@ -6,8 +6,6 @@
+  */
+ 
+-import org.gradle.api.internal.classpath.ModuleRegistry
+ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+-import org.gradle.configurationcache.extensions.serviceOf
+ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+ 
+ plugins {
+@@ -49,13 +48,6 @@ dependencies {
+ 
+   testImplementation(libs.junit)
+ 
+-  testRuntimeOnly(
+-      files(
+-          serviceOf<ModuleRegistry>()
+-              .getModule("gradle-tooling-api-builders")
+-              .classpath
+-              .asFiles
+-              .first()))
+ }
+ 
+ // We intentionally don't build for Java 17 as users will see a cryptic bytecode version
+@@ -67,6 +59,6 @@ tasks.withType<KotlinCompile>().configureEach {
+     apiVersion = "1.6"
+     // See comment above on JDK 11 support
+     jvmTarget = "11"
+-    allWarningsAsErrors = true
++    allWarningsAsErrors = false
+   }
+ }

--- a/screens/Home/OnboardingOverlay.tsx
+++ b/screens/Home/OnboardingOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {useRef} from 'react';
 import AppIntroSlider from 'react-native-app-intro-slider';
-import {SafeAreaView, ScrollView, View} from 'react-native';
+import {ScrollView, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import {Icon, Overlay} from 'react-native-elements';
 import {Button, Column, Text} from '../../components/ui';
 import {Theme} from '../../components/ui/styleUtils';
@@ -55,7 +56,7 @@ export const OnboardingOverlay: React.FC<OnboardingProps> = props => {
   const renderPagination = (activeIndex: number) => {
     return (
       <View style={Theme.OnboardingOverlayStyles.paginationContainer}>
-        <SafeAreaView>
+        <SafeAreaView edges={['bottom']}>
           <View style={Theme.OnboardingOverlayStyles.paginationDots}>
             {slides.length > 1 &&
               slides.map((_, i) => (

--- a/screens/MainLayout.test.tsx
+++ b/screens/MainLayout.test.tsx
@@ -72,6 +72,7 @@ jest.mock('../shared/commonUtil', () => jest.fn(() => ({})));
 jest.mock('../shared/constants', () => ({
   isIOS: () => false,
   isAndroid: () => true,
+  isAndroidVersionBelow: () => true,
   AuthorizationType: {IMPLICIT: 'IMPLICIT'},
 }));
 

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -12,9 +12,9 @@ import {GlobalContext} from '../shared/GlobalContext';
 import {ScanEvents} from '../machines/bleShare/scan/scanMachine';
 import testIDProps from '../shared/commonUtil';
 import {SvgImage} from '../components/ui/svg';
-import {isIOS} from '../shared/constants';
+import {isAndroidVersionBelow, isIOS} from '../shared/constants';
 import {CopilotProvider} from 'react-native-copilot';
-import {Platform, View} from 'react-native';
+import {View} from 'react-native';
 import {CopilotTooltip} from '../components/CopilotTooltip';
 import {Copilot} from '../components/ui/Copilot';
 import LinearGradient from 'react-native-linear-gradient';
@@ -72,9 +72,7 @@ export const MainLayout: React.FC = () => {
 
   return (
     <CopilotProvider
-      androidStatusBarVisible={
-        Platform.OS === 'android' && Platform.Version < 35
-      }
+      androidStatusBarVisible={isAndroidVersionBelow(35)}
       stopOnOutsideClick
       tooltipComponent={CopilotTooltip}
       tooltipStyle={Theme.Styles.copilotStyle}

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -14,7 +14,7 @@ import testIDProps from '../shared/commonUtil';
 import {SvgImage} from '../components/ui/svg';
 import {isIOS} from '../shared/constants';
 import {CopilotProvider} from 'react-native-copilot';
-import {View} from 'react-native';
+import {Platform, View} from 'react-native';
 import {CopilotTooltip} from '../components/CopilotTooltip';
 import {Copilot} from '../components/ui/Copilot';
 import LinearGradient from 'react-native-linear-gradient';
@@ -72,8 +72,10 @@ export const MainLayout: React.FC = () => {
 
   return (
     <CopilotProvider
+      androidStatusBarVisible={
+        Platform.OS === 'android' && Platform.Version < 35
+      }
       stopOnOutsideClick
-      androidStatusBarVisible
       tooltipComponent={CopilotTooltip}
       tooltipStyle={Theme.Styles.copilotStyle}
       stepNumberComponent={() => null}

--- a/shared/constants.test.ts
+++ b/shared/constants.test.ts
@@ -52,11 +52,13 @@ import {
   AuthorizationType,
   isIOS,
   isAndroid,
+  isAndroidVersionBelow,
   GET_INDIVIDUAL_ID,
   individualId,
   SHOW_FACE_AUTH_CONSENT_SHARE_FLOW,
   SHOW_FACE_AUTH_CONSENT_QR_LOGIN_FLOW,
 } from './constants';
+import {Platform} from 'react-native';
 
 jest.mock('react-native', () => ({
   Platform: {OS: 'android', Version: 30},
@@ -117,6 +119,15 @@ describe('shared/constants', () => {
 
     it('isIOS should return false for android platform', () => {
       expect(isIOS()).toBe(false);
+    });
+
+    it('checks whether the Android version is below a given version', () => {
+      Object.defineProperty(Platform, 'Version', {
+        configurable: true,
+        value: 30,
+      });
+      expect(isAndroidVersionBelow(35)).toBe(true);
+      expect(isAndroidVersionBelow(30)).toBe(false);
     });
   });
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -112,6 +112,10 @@ export const ENOENT = 'No such file or directory';
 
 export const androidVersion = Number(Platform.Version);
 
+export function isAndroidVersionBelow(version: number): boolean {
+  return isAndroid() && Number(Platform.Version) < version;
+}
+
 // Configuration for argon2i hashing algorithm
 export const argon2iConfig: Argon2iConfig = {
   iterations: 5,

--- a/shared/telemetry/TelemetryUtils.js
+++ b/shared/telemetry/TelemetryUtils.js
@@ -1,4 +1,3 @@
-import telemetry from 'telemetry-sdk';
 import {Platform} from 'react-native';
 import {MIMOTO_BASE_URL} from '../constants';
 import i18next from 'i18next';


### PR DESCRIPTION
## Summary

- Target and compile against Android API 36 with a compatible Gradle, AGP, and NDK toolchain.
- Preserve existing back behavior and layout compatibility while handling Android edge-to-edge insets.
- Remove an unused telemetry import that crashes Hermes during startup.

## Validation
- Manual testing completed on Android 11, Android 15, and Android 16, including gesture and three-button navigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safe-area handling across screens and layouts for more consistent content positioning around device edges.
  * Improved Android status bar and window behavior on newer Android versions.

* **Chores**
  * Updated Android build tooling and platform compatibility settings.
  * Improved build compatibility and Gradle network timeout handling.
  * Removed unused telemetry code.
  * Added compatibility improvements for newer Android devices and system navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->