### PR TITLE
fix: redirect to redirect_uri post VP submission if available

### DIFF
--- a/__mocks__/react-native.mock.js
+++ b/__mocks__/react-native.mock.js
@@ -38,6 +38,7 @@ jest.mock('react-native', () => {
         constructUnsignedVPToken: jest.fn(),
         shareVerifiablePresentation: jest.fn(),
         sendErrorToVerifier: jest.fn(),
+        openRedirectUriInBrowser: jest.fn(),
       },
       InjiVciClient: {
         addListener: jest.fn(),

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -5,6 +5,9 @@ import static io.mosip.residentapp.utils.OpenId4VPUtils.parseVPTokenSigningResul
 import static io.mosip.residentapp.utils.OpenId4VPUtils.parseWalletConfig;
 
 import android.annotation.SuppressLint;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.net.Uri;
 import android.util.Base64;
 import android.util.Log;
 
@@ -179,6 +182,24 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
 
         } catch (Exception exception) {
             rejectWithOpenID4VPExceptions(exception, promise);
+        }
+    }
+
+    @ReactMethod
+    public void openRedirectUriInBrowser(String redirectUri, Promise promise) {
+        try {
+            Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(redirectUri));
+            Intent chooser = Intent.createChooser(viewIntent, null);
+            chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            getReactApplicationContext().startActivity(chooser);
+            promise.resolve(true);
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "No application available to open the redirect_uri - " + e.getMessage());
+            promise.resolve(false);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to open the redirect_uri - " + e.getMessage());
+            promise.resolve(false);
         }
     }
 }

--- a/machines/openID4VP/openID4VPActions.test.ts
+++ b/machines/openID4VP/openID4VPActions.test.ts
@@ -49,6 +49,10 @@ jest.mock('../activityLog', () => ({
     LOG_ACTIVITY: jest.fn(log => ({type: 'LOG_ACTIVITY', log})),
   },
 }));
+const mockOpenURL = jest.fn(() => Promise.resolve());
+jest.mock('../../shared/browserUtils', () => ({
+  openURLInSelectedBrowser: (...args: any[]) => mockOpenURL(...(args as [])),
+}));
 jest.mock('../../components/VPShareActivityLogEvent', () => ({
   VPShareActivityLog: {getLogFromObject: jest.fn(obj => obj)},
 }));
@@ -122,6 +126,7 @@ describe('openID4VPActions', () => {
       'resetIsFaceVerificationRetryAttempt',
       'setIsShowLoadingScreen',
       'resetIsShowLoadingScreen',
+      'redirectToVerifier',
     ];
     for (const name of expectedActions) {
       expect(actions).toHaveProperty(name);
@@ -326,6 +331,76 @@ describe('openID4VPActions', () => {
         actions.setAuthenticationResponseForPresentationAuthFlow.assignment
           .authenticationResponse;
       expect(fn({presentationRequest: 'pres-req'}, {})).toBe('pres-req');
+    });
+  });
+
+  describe('redirectToVerifier', () => {
+    const verifierResponse = (redirectUri?: string) => ({
+      data: {
+        status_code: 200,
+        ...(redirectUri ? {redirect_uri: redirectUri} : {}),
+      },
+    });
+
+    it('opens the redirect_uri via the browser chooser', async () => {
+      await actions.redirectToVerifier(
+        {},
+        verifierResponse('https://verifier.example.org/cb'),
+      );
+
+      expect(mockOpenURL).toHaveBeenCalledWith(
+        'https://verifier.example.org/cb',
+      );
+    });
+
+    it('preserves the response_code fragment the verifier expects back', async () => {
+      const redirectUri =
+        'https://verifier.example.org/cb#response_code=sample-response-code';
+
+      await actions.redirectToVerifier({}, verifierResponse(redirectUri));
+
+      expect(mockOpenURL).toHaveBeenCalledWith(redirectUri);
+    });
+
+    it('does not redirect when the verifier returned no redirect_uri', async () => {
+      await actions.redirectToVerifier({}, verifierResponse());
+
+      expect(mockOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when the verifier response is missing', async () => {
+      await actions.redirectToVerifier({}, {});
+
+      expect(mockOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when redirect_uri is not a string', async () => {
+      await actions.redirectToVerifier({}, {data: {redirect_uri: 42}});
+
+      expect(mockOpenURL).not.toHaveBeenCalled();
+    });
+
+    it('swallows a malformed redirect_uri instead of breaking the share flow', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await actions.redirectToVerifier({}, verifierResponse('not a url'));
+
+      expect(mockOpenURL).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('swallows a failure to open the browser instead of breaking the share flow', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockOpenURL.mockRejectedValueOnce(new Error('no activity found'));
+
+      await expect(
+        actions.redirectToVerifier(
+          {},
+          verifierResponse('https://verifier.example.org/cb'),
+        ),
+      ).resolves.toBeUndefined();
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/machines/openID4VP/openID4VPActions.test.ts
+++ b/machines/openID4VP/openID4VPActions.test.ts
@@ -49,10 +49,6 @@ jest.mock('../activityLog', () => ({
     LOG_ACTIVITY: jest.fn(log => ({type: 'LOG_ACTIVITY', log})),
   },
 }));
-const mockOpenURL = jest.fn(() => Promise.resolve());
-jest.mock('../../shared/browserUtils', () => ({
-  openURLInSelectedBrowser: (...args: any[]) => mockOpenURL(...(args as [])),
-}));
 jest.mock('../../components/VPShareActivityLogEvent', () => ({
   VPShareActivityLog: {getLogFromObject: jest.fn(obj => obj)},
 }));
@@ -126,7 +122,6 @@ describe('openID4VPActions', () => {
       'resetIsFaceVerificationRetryAttempt',
       'setIsShowLoadingScreen',
       'resetIsShowLoadingScreen',
-      'redirectToVerifier',
     ];
     for (const name of expectedActions) {
       expect(actions).toHaveProperty(name);
@@ -331,76 +326,6 @@ describe('openID4VPActions', () => {
         actions.setAuthenticationResponseForPresentationAuthFlow.assignment
           .authenticationResponse;
       expect(fn({presentationRequest: 'pres-req'}, {})).toBe('pres-req');
-    });
-  });
-
-  describe('redirectToVerifier', () => {
-    const verifierResponse = (redirectUri?: string) => ({
-      data: {
-        status_code: 200,
-        ...(redirectUri ? {redirect_uri: redirectUri} : {}),
-      },
-    });
-
-    it('opens the redirect_uri via the browser chooser', async () => {
-      await actions.redirectToVerifier(
-        {},
-        verifierResponse('https://verifier.example.org/cb'),
-      );
-
-      expect(mockOpenURL).toHaveBeenCalledWith(
-        'https://verifier.example.org/cb',
-      );
-    });
-
-    it('preserves the response_code fragment the verifier expects back', async () => {
-      const redirectUri =
-        'https://verifier.example.org/cb#response_code=sample-response-code';
-
-      await actions.redirectToVerifier({}, verifierResponse(redirectUri));
-
-      expect(mockOpenURL).toHaveBeenCalledWith(redirectUri);
-    });
-
-    it('does not redirect when the verifier returned no redirect_uri', async () => {
-      await actions.redirectToVerifier({}, verifierResponse());
-
-      expect(mockOpenURL).not.toHaveBeenCalled();
-    });
-
-    it('does not redirect when the verifier response is missing', async () => {
-      await actions.redirectToVerifier({}, {});
-
-      expect(mockOpenURL).not.toHaveBeenCalled();
-    });
-
-    it('does not redirect when redirect_uri is not a string', async () => {
-      await actions.redirectToVerifier({}, {data: {redirect_uri: 42}});
-
-      expect(mockOpenURL).not.toHaveBeenCalled();
-    });
-
-    it('swallows a malformed redirect_uri instead of breaking the share flow', async () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-      await actions.redirectToVerifier({}, verifierResponse('not a url'));
-
-      expect(mockOpenURL).not.toHaveBeenCalled();
-      consoleSpy.mockRestore();
-    });
-
-    it('swallows a failure to open the browser instead of breaking the share flow', async () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      mockOpenURL.mockRejectedValueOnce(new Error('no activity found'));
-
-      await expect(
-        actions.redirectToVerifier(
-          {},
-          verifierResponse('https://verifier.example.org/cb'),
-        ),
-      ).resolves.toBeUndefined();
-
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/machines/openID4VP/openID4VPActions.ts
+++ b/machines/openID4VP/openID4VPActions.ts
@@ -20,7 +20,7 @@ import {
 } from '../../shared/openID4VP/openid4vp.types';
 import OpenID4VP from '../../shared/openID4VP/OpenID4VP';
 import {isDcqlFlow} from '../../shared/openID4VP/OpenID4VPHelper';
-import {openURL} from '../../shared/browserUtils';
+import {openURLInSelectedBrowser} from '../../shared/browserUtils';
 
 // TODO - get this presentation definition list which are alias for scope param
 // from the verifier end point after the endpoint is created and exposed.
@@ -312,7 +312,7 @@ export const openID4VPActions = (model: any) => {
 
       try {
         new URL(redirectUri);
-        await openURL(redirectUri);
+        await openURLInSelectedBrowser(redirectUri);
       } catch (error) {
         console.warn('Error during redirection:', error);
         return;

--- a/machines/openID4VP/openID4VPActions.ts
+++ b/machines/openID4VP/openID4VPActions.ts
@@ -20,7 +20,6 @@ import {
 } from '../../shared/openID4VP/openid4vp.types';
 import OpenID4VP from '../../shared/openID4VP/OpenID4VP';
 import {isDcqlFlow} from '../../shared/openID4VP/OpenID4VPHelper';
-import {openURLInSelectedBrowser} from '../../shared/browserUtils';
 
 // TODO - get this presentation definition list which are alias for scope param
 // from the verifier end point after the endpoint is created and exposed.
@@ -302,21 +301,5 @@ export const openID4VPActions = (model: any) => {
     setAvailableWalletCredentials: model.assign({
       availableWalletCredentials: (_, event) => event.vcs,
     }),
-
-    redirectToVerifier: async (_, event) => {
-      const redirectUri = event?.data?.redirect_uri;
-
-      if (!redirectUri || typeof redirectUri !== 'string') {
-        return;
-      }
-
-      try {
-        new URL(redirectUri);
-        await openURLInSelectedBrowser(redirectUri);
-      } catch (error) {
-        console.warn('Error during redirection:', error);
-        return;
-      }
-    },
   };
 };

--- a/machines/openID4VP/openID4VPMachine.ts
+++ b/machines/openID4VP/openID4VPMachine.ts
@@ -548,7 +548,6 @@ export const openID4VPMachine = model.createMachine(
                       logType: 'SHARED_WITH_FACE_VERIFIACTION',
                     }),
                     sendParent('SUCCESS'),
-                    'redirectToVerifier',
                   ],
                   target: '#success',
                 },
@@ -559,7 +558,6 @@ export const openID4VPMachine = model.createMachine(
                       logType: 'SHARED_SUCCESSFULLY',
                     }),
                     sendParent('SUCCESS'),
-                    'redirectToVerifier',
                   ],
                   target: '#success',
                 },
@@ -629,6 +627,9 @@ export const openID4VPMachine = model.createMachine(
       },
       success: {
         id: 'success',
+        invoke: {
+          src: 'redirectToVerifier',
+        },
       },
       authFlowFailed: {
         entry: [

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -193,6 +193,7 @@ export interface Typegen0 {
       | 'error.platform.OpenID4VP.getTrustedVerifiersList:invocation[0]'
       | 'xstate.stop';
     resetOpenID4VPRetryCount: 'RESET_RETRY_COUNT';
+    redirectToVerifier: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     setAuthenticationError: 'error.platform.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponse: 'done.invoke.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponseForPresentationAuthFlow: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -93,6 +93,7 @@ export interface Typegen0 {
     getSelectedKey: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     isVerifierTrusted: 'done.invoke.OpenID4VP.checkVerifierTrust:invocation[0]';
     sendSelectedCredentialsForVP: 'done.invoke.OpenID4VP.sendingVP.constructVP.constructing:invocation[0]';
+    redirectToVerifier: 'done.invoke.OpenID4VP.success:invocation[0]';
     sendVP: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     shareDeclineStatus: 'done.invoke.OpenID4VP.shareVPDeclineStatusToVerifier:invocation[0]';
     shouldValidateClient: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';
@@ -159,6 +160,7 @@ export interface Typegen0 {
       | 'getKeyPair'
       | 'getSelectedKey'
       | 'isVerifierTrusted'
+      | 'redirectToVerifier'
       | 'sendSelectedCredentialsForVP'
       | 'sendVP'
       | 'shareDeclineStatus'
@@ -193,7 +195,6 @@ export interface Typegen0 {
       | 'error.platform.OpenID4VP.getTrustedVerifiersList:invocation[0]'
       | 'xstate.stop';
     resetOpenID4VPRetryCount: 'RESET_RETRY_COUNT';
-    redirectToVerifier: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     setAuthenticationError: 'error.platform.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponse: 'done.invoke.OpenID4VP.authenticateVerifier:invocation[0]';
     setAuthenticationResponseForPresentationAuthFlow: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
@@ -274,6 +275,7 @@ export interface Typegen0 {
     isVerifierTrusted:
       | 'done.invoke.OpenID4VP.authenticateVerifier:invocation[0]'
       | 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
+    redirectToVerifier: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     sendSelectedCredentialsForVP: '' | 'SIGN_VP';
     sendVP: '';
     shareDeclineStatus: 'CONFIRM';

--- a/machines/openID4VP/openID4VPMachine.typegen.ts
+++ b/machines/openID4VP/openID4VPMachine.typegen.ts
@@ -92,8 +92,8 @@ export interface Typegen0 {
     getKeyPair: 'done.invoke.OpenID4VP.getKeyPairFromKeystore:invocation[0]';
     getSelectedKey: 'done.invoke.OpenID4VP.checkKeyPair:invocation[0]';
     isVerifierTrusted: 'done.invoke.OpenID4VP.checkVerifierTrust:invocation[0]';
+    redirectToVerifier: 'done.invoke.success:invocation[0]';
     sendSelectedCredentialsForVP: 'done.invoke.OpenID4VP.sendingVP.constructVP.constructing:invocation[0]';
-    redirectToVerifier: 'done.invoke.OpenID4VP.success:invocation[0]';
     sendVP: 'done.invoke.OpenID4VP.sendingVP.sendVP:invocation[0]';
     shareDeclineStatus: 'done.invoke.OpenID4VP.shareVPDeclineStatusToVerifier:invocation[0]';
     shouldValidateClient: 'done.invoke.OpenID4VP.checkIfClientValidationIsRequired:invocation[0]';

--- a/machines/openID4VP/openID4VPServices.test.ts
+++ b/machines/openID4VP/openID4VPServices.test.ts
@@ -27,6 +27,11 @@ jest.mock('../../shared/constants', () => ({
   OVP_ERROR_CODE: {DECLINED: 'declined'},
   OVP_ERROR_MESSAGES: {DECLINED: 'User declined'},
 }));
+const mockOpenURLInSelectedBrowser = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../shared/browserUtils', () => ({
+  openURLInSelectedBrowser: (...args: any[]) =>
+    mockOpenURLInSelectedBrowser(...(args as [])),
+}));
 jest.mock('../../shared/Utils', () => ({
   getVerifierKey: jest.fn(() => 'verifierKey'),
   VCShareFlowType: {
@@ -205,5 +210,56 @@ describe('openID4VPServices', () => {
     const fn = services.sendSelectedCredentialsForVP(context);
     await fn();
     expect(OpenID4VP.prepareCredentialsForVPSharing).toHaveBeenCalled();
+  });
+
+  describe('redirectToVerifier', () => {
+    const verifierResponse = (redirectUri?: unknown) => ({
+      data: {
+        status_code: 200,
+        ...(redirectUri ? {redirect_uri: redirectUri} : {}),
+      },
+    });
+
+    it('redirects to the redirect_uri returned by the verifier', async () => {
+      const redirectUri = 'https://verifier.example.org/cb#response_code=abc';
+
+      await services.redirectToVerifier({}, verifierResponse(redirectUri))();
+
+      expect(mockOpenURLInSelectedBrowser).toHaveBeenCalledWith(redirectUri);
+    });
+
+    it('does not redirect when the verifier returned no redirect_uri', async () => {
+      await services.redirectToVerifier({}, verifierResponse())();
+
+      expect(mockOpenURLInSelectedBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when the redirect_uri is not a string', async () => {
+      await services.redirectToVerifier({}, verifierResponse(42))();
+
+      expect(mockOpenURLInSelectedBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when the redirect_uri is malformed', async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+
+      await services.redirectToVerifier({}, verifierResponse('not a url'))();
+
+      expect(mockOpenURLInSelectedBrowser).not.toHaveBeenCalled();
+    });
+
+    it('never rejects when the browser could not be opened', async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockOpenURLInSelectedBrowser.mockRejectedValueOnce(
+        new Error('no activity found'),
+      );
+
+      await expect(
+        services.redirectToVerifier(
+          {},
+          verifierResponse('https://verifier.example.org/cb'),
+        )(),
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/machines/openID4VP/openID4VPServices.ts
+++ b/machines/openID4VP/openID4VPServices.ts
@@ -2,12 +2,11 @@ import {CACHED_API} from '../../shared/api';
 import OpenID4VP from '../../shared/openID4VP/OpenID4VP';
 import {OVP_ERROR_CODE, OVP_ERROR_MESSAGES} from '../../shared/constants';
 import {getVerifierKey, VCShareFlowType} from '../../shared/Utils';
-import {
-  signDataForVpPreparation,
-} from '../../shared/openID4VP/OpenID4VPHelper';
+import {signDataForVpPreparation} from '../../shared/openID4VP/OpenID4VPHelper';
 import {NativeModules} from 'react-native';
 import VciClient from '../../shared/vciClient/VciClient';
 import {SelectedCredentialsForVPSharing} from '../VerifiableCredential/VCMetaMachine/vc';
+import {openURLInSelectedBrowser} from '../../shared/browserUtils';
 
 export const signatureSuite = 'JsonWebSignature2020';
 
@@ -111,6 +110,20 @@ export const openID4VPServices = () => {
         throw new Error('VERIFIER_RESPONSE_ERROR');
       }
       return verifierResponse;
+    },
+
+    redirectToVerifier: (_: any, event: any) => async () => {
+      const redirectUri = event?.data?.redirect_uri;
+      if (!redirectUri || typeof redirectUri !== 'string') {
+        return;
+      }
+
+      try {
+        new URL(redirectUri);
+        await openURLInSelectedBrowser(redirectUri);
+      } catch (error) {
+        console.warn('Error during redirection:', error);
+      }
     },
   };
 };

--- a/shared/browserUtils.test.ts
+++ b/shared/browserUtils.test.ts
@@ -8,6 +8,7 @@ const redirectUri =
   'https://verifier.example.org/cb#response_code=sample-response-code';
 
 describe('browserUtils', () => {
+  const injiOpenID4VP = NativeModules.InjiOpenID4VP;
   let openRedirectUriInBrowser: jest.Mock;
   let openURLSpy: jest.SpyInstance;
   let shareSpy: jest.SpyInstance;
@@ -16,11 +17,10 @@ describe('browserUtils', () => {
     jest.clearAllMocks();
     (isIOS as jest.Mock).mockReturnValue(false);
 
-    NativeModules.InjiOpenID4VP.openRedirectUriInBrowser = jest
-      .fn()
-      .mockResolvedValue(true);
-    openRedirectUriInBrowser = NativeModules.InjiOpenID4VP
-      .openRedirectUriInBrowser as jest.Mock;
+    (NativeModules as any).InjiOpenID4VP = injiOpenID4VP;
+    injiOpenID4VP.openRedirectUriInBrowser = jest.fn().mockResolvedValue(true);
+    openRedirectUriInBrowser =
+      injiOpenID4VP.openRedirectUriInBrowser as jest.Mock;
 
     openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
     shareSpy = jest
@@ -29,8 +29,8 @@ describe('browserUtils', () => {
   });
 
   afterEach(() => {
-    openURLSpy.mockRestore();
-    shareSpy.mockRestore();
+    (NativeModules as any).InjiOpenID4VP = injiOpenID4VP;
+    jest.restoreAllMocks();
   });
 
   describe('openURL', () => {
@@ -66,14 +66,11 @@ describe('browserUtils', () => {
     });
 
     it('falls back to the default browser when the native module is unavailable', async () => {
-      const module = NativeModules.InjiOpenID4VP;
       (NativeModules as any).InjiOpenID4VP = undefined;
 
       await openURLInSelectedBrowser(redirectUri);
 
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
-
-      (NativeModules as any).InjiOpenID4VP = module;
     });
   });
 
@@ -93,12 +90,11 @@ describe('browserUtils', () => {
 
     it('falls back to the default browser when the share sheet cannot be shown', async () => {
       shareSpy.mockRejectedValue(new Error('could not present'));
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'warn').mockImplementation();
 
       await openURLInSelectedBrowser(redirectUri);
 
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/shared/browserUtils.test.ts
+++ b/shared/browserUtils.test.ts
@@ -1,0 +1,61 @@
+import {Linking, NativeModules} from 'react-native';
+import {openURL, openURLInSelectedBrowser} from './browserUtils';
+import {isIOS} from './constants';
+
+jest.mock('./constants', () => ({isIOS: jest.fn(() => false)}));
+
+const redirectUri =
+  'https://verifier.example.org/cb#response_code=sample-response-code';
+
+describe('browserUtils', () => {
+  let openRedirectUriInBrowser: jest.Mock;
+  let openURLSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isIOS as jest.Mock).mockReturnValue(false);
+
+    openRedirectUriInBrowser = NativeModules.InjiOpenID4VP
+      .openRedirectUriInBrowser as jest.Mock;
+    openRedirectUriInBrowser.mockResolvedValue(true);
+
+    openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
+  });
+
+  afterEach(() => openURLSpy.mockRestore());
+
+  describe('openURL', () => {
+    it('opens the url in the default browser', async () => {
+      await openURL(redirectUri);
+
+      expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+    });
+  });
+
+  describe('openURLInSelectedBrowser', () => {
+    it('offers the browser chooser on android', async () => {
+      await openURLInSelectedBrowser(redirectUri);
+
+      expect(openRedirectUriInBrowser).toHaveBeenCalledWith(redirectUri);
+      expect(openURLSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default browser when no browser could be chosen', async () => {
+      openRedirectUriInBrowser.mockResolvedValue(false);
+
+      await openURLInSelectedBrowser(redirectUri);
+
+      expect(openRedirectUriInBrowser).toHaveBeenCalledWith(redirectUri);
+      expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+    });
+
+    it('opens the default browser on ios, which cannot offer a chooser', async () => {
+      (isIOS as jest.Mock).mockReturnValue(true);
+
+      await openURLInSelectedBrowser(redirectUri);
+
+      expect(openRedirectUriInBrowser).not.toHaveBeenCalled();
+      expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+    });
+  });
+});

--- a/shared/browserUtils.test.ts
+++ b/shared/browserUtils.test.ts
@@ -15,9 +15,11 @@ describe('browserUtils', () => {
     jest.clearAllMocks();
     (isIOS as jest.Mock).mockReturnValue(false);
 
+    NativeModules.InjiOpenID4VP.openRedirectUriInBrowser = jest
+      .fn()
+      .mockResolvedValue(true);
     openRedirectUriInBrowser = NativeModules.InjiOpenID4VP
       .openRedirectUriInBrowser as jest.Mock;
-    openRedirectUriInBrowser.mockResolvedValue(true);
 
     openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
   });
@@ -46,6 +48,14 @@ describe('browserUtils', () => {
       await openURLInSelectedBrowser(redirectUri);
 
       expect(openRedirectUriInBrowser).toHaveBeenCalledWith(redirectUri);
+      expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+    });
+
+    it('falls back to the default browser when the native module has no chooser method', async () => {
+      delete (NativeModules.InjiOpenID4VP as any).openRedirectUriInBrowser;
+
+      await openURLInSelectedBrowser(redirectUri);
+
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
     });
 

--- a/shared/browserUtils.test.ts
+++ b/shared/browserUtils.test.ts
@@ -1,4 +1,4 @@
-import {Linking, NativeModules} from 'react-native';
+import {Linking, NativeModules, Share} from 'react-native';
 import {openURL, openURLInSelectedBrowser} from './browserUtils';
 import {isIOS} from './constants';
 
@@ -10,6 +10,7 @@ const redirectUri =
 describe('browserUtils', () => {
   let openRedirectUriInBrowser: jest.Mock;
   let openURLSpy: jest.SpyInstance;
+  let shareSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -22,9 +23,15 @@ describe('browserUtils', () => {
       .openRedirectUriInBrowser as jest.Mock;
 
     openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
+    shareSpy = jest
+      .spyOn(Share, 'share')
+      .mockResolvedValue({action: Share.sharedAction} as any);
   });
 
-  afterEach(() => openURLSpy.mockRestore());
+  afterEach(() => {
+    openURLSpy.mockRestore();
+    shareSpy.mockRestore();
+  });
 
   describe('openURL', () => {
     it('opens the url in the default browser', async () => {
@@ -34,8 +41,8 @@ describe('browserUtils', () => {
     });
   });
 
-  describe('openURLInSelectedBrowser', () => {
-    it('offers the browser chooser on android', async () => {
+  describe('openURLInSelectedBrowser on android', () => {
+    it('offers the system browser chooser', async () => {
       await openURLInSelectedBrowser(redirectUri);
 
       expect(openRedirectUriInBrowser).toHaveBeenCalledWith(redirectUri);
@@ -47,7 +54,6 @@ describe('browserUtils', () => {
 
       await openURLInSelectedBrowser(redirectUri);
 
-      expect(openRedirectUriInBrowser).toHaveBeenCalledWith(redirectUri);
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
     });
 
@@ -59,13 +65,40 @@ describe('browserUtils', () => {
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
     });
 
-    it('opens the default browser on ios, which cannot offer a chooser', async () => {
-      (isIOS as jest.Mock).mockReturnValue(true);
+    it('falls back to the default browser when the native module is unavailable', async () => {
+      const module = NativeModules.InjiOpenID4VP;
+      (NativeModules as any).InjiOpenID4VP = undefined;
 
       await openURLInSelectedBrowser(redirectUri);
 
-      expect(openRedirectUriInBrowser).not.toHaveBeenCalled();
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+
+      (NativeModules as any).InjiOpenID4VP = module;
+    });
+  });
+
+  describe('openURLInSelectedBrowser on ios', () => {
+    beforeEach(() => (isIOS as jest.Mock).mockReturnValue(true));
+
+    it('offers the share sheet, which lists the installed browsers', async () => {
+      await openURLInSelectedBrowser(redirectUri);
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        url: redirectUri,
+        message: redirectUri,
+      });
+      expect(openRedirectUriInBrowser).not.toHaveBeenCalled();
+      expect(openURLSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default browser when the share sheet cannot be shown', async () => {
+      shareSpy.mockRejectedValue(new Error('could not present'));
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await openURLInSelectedBrowser(redirectUri);
+
+      expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/shared/browserUtils.test.ts
+++ b/shared/browserUtils.test.ts
@@ -1,4 +1,4 @@
-import {Linking, NativeModules, Share} from 'react-native';
+import {Linking, NativeModules} from 'react-native';
 import {openURL, openURLInSelectedBrowser} from './browserUtils';
 import {isIOS} from './constants';
 
@@ -11,7 +11,6 @@ describe('browserUtils', () => {
   const injiOpenID4VP = NativeModules.InjiOpenID4VP;
   let openRedirectUriInBrowser: jest.Mock;
   let openURLSpy: jest.SpyInstance;
-  let shareSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -23,9 +22,6 @@ describe('browserUtils', () => {
       injiOpenID4VP.openRedirectUriInBrowser as jest.Mock;
 
     openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
-    shareSpy = jest
-      .spyOn(Share, 'share')
-      .mockResolvedValue({action: Share.sharedAction} as any);
   });
 
   afterEach(() => {
@@ -77,24 +73,11 @@ describe('browserUtils', () => {
   describe('openURLInSelectedBrowser on ios', () => {
     beforeEach(() => (isIOS as jest.Mock).mockReturnValue(true));
 
-    it('offers the share sheet, which lists the installed browsers', async () => {
-      await openURLInSelectedBrowser(redirectUri);
-
-      expect(shareSpy).toHaveBeenCalledWith({
-        url: redirectUri,
-        message: redirectUri,
-      });
-      expect(openRedirectUriInBrowser).not.toHaveBeenCalled();
-      expect(openURLSpy).not.toHaveBeenCalled();
-    });
-
-    it('falls back to the default browser when the share sheet cannot be shown', async () => {
-      shareSpy.mockRejectedValue(new Error('could not present'));
-      jest.spyOn(console, 'warn').mockImplementation();
-
+    it('opens the default browser, since ios cannot offer a browser chooser', async () => {
       await openURLInSelectedBrowser(redirectUri);
 
       expect(openURLSpy).toHaveBeenCalledWith(redirectUri);
+      expect(openRedirectUriInBrowser).not.toHaveBeenCalled();
     });
   });
 });

--- a/shared/browserUtils.ts
+++ b/shared/browserUtils.ts
@@ -1,5 +1,20 @@
-import {Linking} from 'react-native';
+import {Linking, NativeModules} from 'react-native';
+import {isIOS} from './constants';
 
 export async function openURL(url: string): Promise<void> {
   await Linking.openURL(url);
+}
+
+export async function openURLInSelectedBrowser(url: string): Promise<void> {
+  if (isIOS()) {
+    await openURL(url);
+    return;
+  }
+
+  const openedInChosenBrowser =
+    await NativeModules.InjiOpenID4VP?.openRedirectUriInBrowser(url);
+
+  if (!openedInChosenBrowser) {
+    await openURL(url);
+  }
 }

--- a/shared/browserUtils.ts
+++ b/shared/browserUtils.ts
@@ -12,7 +12,7 @@ export async function openURLInSelectedBrowser(url: string): Promise<void> {
   }
 
   const openedInChosenBrowser =
-    await NativeModules.InjiOpenID4VP?.openRedirectUriInBrowser(url);
+    await NativeModules.InjiOpenID4VP?.openRedirectUriInBrowser?.(url);
 
   if (!openedInChosenBrowser) {
     await openURL(url);

--- a/shared/browserUtils.ts
+++ b/shared/browserUtils.ts
@@ -1,4 +1,4 @@
-import {Linking, NativeModules, Share} from 'react-native';
+import {Linking, NativeModules} from 'react-native';
 import {isIOS} from './constants';
 
 export async function openURL(url: string): Promise<void> {
@@ -7,12 +7,7 @@ export async function openURL(url: string): Promise<void> {
 
 export async function openURLInSelectedBrowser(url: string): Promise<void> {
   if (isIOS()) {
-    try {
-      await Share.share({url, message: url});
-    } catch (error) {
-      console.warn('Error while showing the browser choice sheet:', error);
-      await openURL(url);
-    }
+    await openURL(url);
     return;
   }
 

--- a/shared/browserUtils.ts
+++ b/shared/browserUtils.ts
@@ -1,4 +1,4 @@
-import {Linking, NativeModules} from 'react-native';
+import {Linking, NativeModules, Share} from 'react-native';
 import {isIOS} from './constants';
 
 export async function openURL(url: string): Promise<void> {
@@ -7,7 +7,12 @@ export async function openURL(url: string): Promise<void> {
 
 export async function openURLInSelectedBrowser(url: string): Promise<void> {
   if (isIOS()) {
-    await openURL(url);
+    try {
+      await Share.share({url, message: url});
+    } catch (error) {
+      console.warn('Error while showing the browser choice sheet:', error);
+      await openURL(url);
+    }
     return;
   }
 


### PR DESCRIPTION
## Description

> Redirects the end-user's browser to the redirect_uri returned by the Verifier after VP submission, as required by [OpenID4VP 1.0 §8.2](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.2).

Browser selection: adds openRedirectUriInBrowser to InjiOpenID4VPModule, which opens the redirect_uri through Android's system chooser so the user picks from the browsers installed on the device. Falls back to the default browser if no chooser can be shown.

Test coverage for redirectToVerifier and browserUtils

## Attaching screen shot of conformance suite  for reference

<img width="1923" height="868" alt="Screenshot from 2026-08-18 13-40-02" src="https://github.com/user-attachments/assets/c5a0a69d-423e-47be-a6c0-d540b6fd50b8" />

<img width="1923" height="868" alt="image" src="https://github.com/user-attachments/assets/a82b12dd-e2f7-4d60-b838-2108a5137610" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic redirection to the verifier’s browser after a successful presentation.
  - Android users can choose which browser opens the verifier link.
  - Falls back to the default browser when no chooser or compatible browser is available.

- **Bug Fixes**
  - Invalid, missing, or malformed verifier redirect links no longer trigger browser navigation.
  - Browser-opening behavior is now consistent across Android and iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->