### PR TITLE
feat(vci): select holder proof binding from issuer metadata

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiVCIClientCallback.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVCIClientCallback.kt
@@ -1,5 +1,6 @@
 package io.mosip.residentapp
 
+import io.mosip.vciclient.proof.CredentialRequestProofMetadata
 import android.util.Base64
 import android.util.Log
 import com.facebook.react.bridge.Arguments
@@ -140,18 +141,23 @@ object VCIClientCallbackBridge {
         return deferredIssuerTrustResponse!!
     }
 
-    fun emitRequestProof(
-            context: ReactApplicationContext,
-            credentialIssuer: String,
-            cNonce: String?,
-            proofSigningAlgorithmsSupported: List<String>,
-    ) {
+    fun emitRequestProof(context: ReactApplicationContext, credentialRequestProofMetadata: CredentialRequestProofMetadata) {
         val params =
                 Arguments.createMap().apply {
-                    putString("credentialIssuer", credentialIssuer)
-                    if (cNonce != null) putString("cNonce", cNonce)
-                    val json = gson.toJson(proofSigningAlgorithmsSupported)
-                    putString("proofSigningAlgorithmsSupported", json)
+                    putString("credentialIssuer", credentialRequestProofMetadata.credentialIssuer)
+                    credentialRequestProofMetadata.nonce?.let { putString("cNonce", it) }
+                    putString(
+                            "proofSigningAlgorithmsSupported",
+                            gson.toJson(credentialRequestProofMetadata.proofSigningAlgorithmsSupported)
+                    )
+                    putString(
+                            "cryptographicBindingMethodsSupported",
+                            gson.toJson(credentialRequestProofMetadata.cryptographicBindingMethodsSupported)
+                    )
+                    putString(
+                            "proofTypesSupported",
+                            gson.toJson(credentialRequestProofMetadata.proofTypesSupported)
+                    )
                 }
         context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
                 .emit("onRequestProof", params)

--- a/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
@@ -127,17 +127,9 @@ object VCIClientBridge {
 
 
     private fun getProofsCallback(): ProofsCallback =
-            {
-                    credentialIssuer: String,
-                    cNonce: String?,
-                    proofSigningAlgorithmsSupported: List<String> ->
+            { credentialRequestProofMetadata ->
                 VCIClientCallbackBridge.createProofDeferred()
-                VCIClientCallbackBridge.emitRequestProof(
-                        reactContext,
-                        credentialIssuer,
-                        cNonce,
-                        proofSigningAlgorithmsSupported
-                )
+                VCIClientCallbackBridge.emitRequestProof(reactContext, credentialRequestProofMetadata)
                 CredentialRequestProofs(proofs = listOf(VCIClientCallbackBridge.awaitProof()))
             }
 

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -97,7 +97,7 @@
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "0c36acbb954634c3354e4634da407b2d9539d15d"
+        "revision" : "61baaedbce7e24aa9fe5198401bc2e4b2abdf843"
       }
     },
     {

--- a/ios/RNVCIClientModule.swift
+++ b/ios/RNVCIClientModule.swift
@@ -87,12 +87,8 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
           getTokenResponse: { tokenRequest in
             try await self.getTokenResponseHook(tokenRequest: tokenRequest)
           },
-          getProofs: { credentialIssuer, cNonce, algos in
-            try await self.getProofsContinuationHook(
-              credentialIssuer: credentialIssuer,
-              cNonce: cNonce,
-              proofSigningAlgorithmsSupported: algos
-            )
+          getProofs: { credentialRequestProofMetadata in
+            try await self.getProofsContinuationHook(credentialRequestProofMetadata: credentialRequestProofMetadata)
           },
           onCheckIssuerTrust: { credentialIssuer, issuerDisplay in
             try await self.getIssuerTrustDecisionHook(
@@ -135,12 +131,8 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
             try await self.getTokenResponseHook(tokenRequest: tokenRequest)
           },
           authorizationMethods: try getSupportedAuthorizationMethods(openId4VpWalletConfig: openId4VpWalletConfig),
-          getProofs: { credentialIssuer, cNonce, algos in
-            try await self.getProofsContinuationHook(
-              credentialIssuer: credentialIssuer,
-              cNonce: cNonce,
-              proofSigningAlgorithmsSupported: algos
-            )
+          getProofs: { credentialRequestProofMetadata in
+            try await self.getProofsContinuationHook(credentialRequestProofMetadata: credentialRequestProofMetadata)
           },
           downloadTimeoutInMillis: 200000)
 
@@ -267,34 +259,37 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
   }
 
   private func getProofsContinuationHook(
-    credentialIssuer: String,
-    cNonce: String?,
-    proofSigningAlgorithmsSupported: [String]
+    credentialRequestProofMetadata: CredentialRequestProofMetadata
   ) async throws -> CredentialRequestProofs {
-    let proof = try await getProofContinuationHook(
-      credentialIssuer: credentialIssuer,
-      cNonce: cNonce,
-      proofSigningAlgorithmsSupported: proofSigningAlgorithmsSupported
-    )
+    let proof = try await getProofContinuationHook(credentialRequestProofMetadata: credentialRequestProofMetadata)
 
     return CredentialRequestProofs(proofs: [proof])
   }
 
+  private func jsonString(_ values: [String]) -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: values, options: []),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "[]"
+    }
+
+    return json
+  }
+
   private func getProofContinuationHook(
-    credentialIssuer: String,
-    cNonce: String?,
-    proofSigningAlgorithmsSupported: [String]
+    credentialRequestProofMetadata: CredentialRequestProofMetadata
   ) async throws -> String {
-    let jsonData = try JSONSerialization.data(
-      withJSONObject: proofSigningAlgorithmsSupported, options: [])
-    let jsonString = String(data: jsonData, encoding: .utf8) ?? "[]"
     if let bridge = RCTBridge.current() {
       bridge.eventDispatcher().sendAppEvent(
         withName: "onRequestProof",
         body: [
-          "credentialIssuer": credentialIssuer,
-          "cNonce": cNonce,
-          "proofSigningAlgorithmsSupported": jsonString,
+          "credentialIssuer": credentialRequestProofMetadata.credentialIssuer,
+          "cNonce": credentialRequestProofMetadata.nonce,
+          "proofSigningAlgorithmsSupported": jsonString(
+            credentialRequestProofMetadata.proofSigningAlgorithmsSupported),
+          "cryptographicBindingMethodsSupported": jsonString(
+            credentialRequestProofMetadata.cryptographicBindingMethodsSupported),
+          "proofTypesSupported": jsonString(credentialRequestProofMetadata.proofTypesSupported),
         ]
       )
     }

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -179,7 +179,7 @@ describe('IssuersActions', () => {
       'setRequestTxCode',
       'resetRequestTxCode',
       'setCredentialOfferIssuerWellknownResponse',
-      'setWellknwonKeyTypes',
+      'setProofMetadata',
       'setSelectedCredentialIssuer',
       'setTokenRequestObject',
       'setTokenResponseObject',
@@ -592,9 +592,8 @@ describe('IssuersActions', () => {
       expect(fn({}, {data: {message: 'verify err'}})).toBe('verify err');
     });
 
-    it('setWellknwonKeyTypes sets from event', () => {
-      const fn =
-        actions.setWellknwonKeyTypes.assignment.jwtProofSigningAlgorithms;
+    it('setProofMetadata sets from event', () => {
+      const fn = actions.setProofMetadata.assignment.jwtProofSigningAlgorithms;
       expect(fn({}, {proofSigningAlgosSupported: ['ES256']})).toEqual([
         'ES256',
       ]);

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -330,13 +330,16 @@ describe('IssuersActions', () => {
         },
       };
       expect(asg.selectedCredentialType({}, event)).toEqual(event.credType);
-      expect(asg.wellknownKeyTypes({}, event)).toEqual(['ES256']);
+      expect(asg.jwtProofSigningAlgorithms({}, event)).toEqual(['ES256']);
     });
 
     it('setSelectedCredentialType returns empty for no jwt', () => {
       const asg = actions.setSelectedCredentialType.assignment;
       expect(
-        asg.wellknownKeyTypes({}, {credType: {proof_types_supported: {}}}),
+        asg.jwtProofSigningAlgorithms(
+          {},
+          {credType: {proof_types_supported: {}}},
+        ),
       ).toEqual([]);
     });
 
@@ -590,7 +593,8 @@ describe('IssuersActions', () => {
     });
 
     it('setWellknwonKeyTypes sets from event', () => {
-      const fn = actions.setWellknwonKeyTypes.assignment.wellknownKeyTypes;
+      const fn =
+        actions.setWellknwonKeyTypes.assignment.jwtProofSigningAlgorithms;
       expect(fn({}, {proofSigningAlgosSupported: ['ES256']})).toEqual([
         'ES256',
       ]);

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -15,6 +15,12 @@ jest.mock('../../shared/openId4VCI/Utils', () => ({
     WALLET_GENERIC_ERROR: 'wallet_generic_error',
   },
   getDisplayObjectForCurrentLanguage: jest.fn(arr => arr?.[0]),
+  getJwtProofSigningAlgorithms: jest.fn(
+    credType =>
+      credType?.proof_types_supported?.jwt
+        ?.proof_signing_alg_values_supported ?? [],
+  ),
+  selectBindingMethod: jest.fn(() => 'did:jwk'),
   Issuers_Key_Ref: 'issuers_key_ref',
   VCIServerErrorCode: {
     SERVER_ERROR: 'server_error',
@@ -711,10 +717,13 @@ describe('IssuersActions', () => {
       ).toBe(true);
     });
 
-    it('setSelectedKey calls selectCredentialRequestKey', () => {
+    it('setSelectedKey reads the key type and binding chosen by getKeyOrderList', () => {
       const fn = actions.setSelectedKey.assignment.keyType;
-      const result = fn({wellknownKeyTypes: ['ES256']}, {data: 'someData'});
-      expect(result).toBe('ES256');
+      const event = {data: {keyType: 'ES256', bindingMethod: 'jwk'}};
+      expect(fn({}, event)).toBe('ES256');
+      expect(actions.setSelectedKey.assignment.bindingMethod({}, event)).toBe(
+        'jwk',
+      );
     });
 
     it('setCredentialOfferIssuerWellknownResponse sets selectedIssuer and wellknown', () => {

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -86,7 +86,7 @@ export const IssuersActions = (model: any) => {
     }),
     setSelectedCredentialType: model.assign({
       selectedCredentialType: (_: any, event: any) => event.credType,
-      wellknownKeyTypes: (_: any, event: any) =>
+      jwtProofSigningAlgorithms: (_: any, event: any) =>
         getJwtProofSigningAlgorithms(event.credType),
       proofTypesSupported: (_: any, event: any) =>
         Object.keys(event.credType.proof_types_supported ?? {}),
@@ -350,7 +350,7 @@ export const IssuersActions = (model: any) => {
       },
     }),
     setWellknwonKeyTypes: model.assign({
-      wellknownKeyTypes: (_: any, event: any) => {
+      jwtProofSigningAlgorithms: (_: any, event: any) => {
         return event.proofSigningAlgosSupported;
       },
       cryptographicBindingMethods: (_: any, event: any) =>

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -2,7 +2,7 @@ import {
   ErrorMessage,
   getDisplayObjectForCurrentLanguage,
   Issuers_Key_Ref,
-  selectCredentialRequestKey,
+  getJwtProofSigningAlgorithms,
   VCIServerErrorCode,
 } from '../../shared/openId4VCI/Utils';
 import {
@@ -86,15 +86,13 @@ export const IssuersActions = (model: any) => {
     }),
     setSelectedCredentialType: model.assign({
       selectedCredentialType: (_: any, event: any) => event.credType,
-      wellknownKeyTypes: (_: any, event: any) => {
-        const proofTypesSupported = event.credType.proof_types_supported;
-        if (proofTypesSupported?.jwt) {
-          return proofTypesSupported.jwt
-            .proof_signing_alg_values_supported as string[];
-        } else {
-          return [] as string[];
-        }
-      },
+      wellknownKeyTypes: (_: any, event: any) =>
+        getJwtProofSigningAlgorithms(event.credType),
+      proofTypesSupported: (_: any, event: any) =>
+        Object.keys(event.credType.proof_types_supported ?? {}),
+      cryptographicBindingMethods: (_: any, event: any) =>
+        (event.credType.cryptographic_binding_methods_supported ??
+          []) as string[],
     }),
     setSupportedCredentialTypes: model.assign({
       supportedCredentialTypes: (_: any, event: any) => event.data,
@@ -245,13 +243,8 @@ export const IssuersActions = (model: any) => {
     ),
 
     setSelectedKey: model.assign({
-      keyType: (context: any, event: any) => {
-        const keyType = selectCredentialRequestKey(
-          context.wellknownKeyTypes,
-          event.data,
-        );
-        return keyType;
-      },
+      keyType: (_: any, event: any) => event.data.keyType,
+      bindingMethod: (_: any, event: any) => event.data.bindingMethod,
     }),
 
     setSelectedIssuers: model.assign({
@@ -360,6 +353,10 @@ export const IssuersActions = (model: any) => {
       wellknownKeyTypes: (_: any, event: any) => {
         return event.proofSigningAlgosSupported;
       },
+      cryptographicBindingMethods: (_: any, event: any) =>
+        event.cryptographicBindingMethodsSupported ?? [],
+      proofTypesSupported: (_: any, event: any) =>
+        event.proofTypesSupported ?? [],
     }),
     setSelectedCredentialIssuer: model.assign({
       credentialOfferCredentialIssuer: (_: any, event: any) => {

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -349,7 +349,7 @@ export const IssuersActions = (model: any) => {
         return event.data;
       },
     }),
-    setWellknwonKeyTypes: model.assign({
+    setProofMetadata: model.assign({
       jwtProofSigningAlgorithms: (_: any, event: any) => {
         return event.proofSigningAlgosSupported;
       },

--- a/machines/Issuers/IssuersMachine.ts
+++ b/machines/Issuers/IssuersMachine.ts
@@ -197,7 +197,7 @@ export const IssuersMachine = model.createMachine(
           PROOF_REQUEST: {
             actions: [
               'setCNonce',
-              'setWellknwonKeyTypes',
+              'setProofMetadata',
               'setSelectedCredentialIssuer',
             ],
             target: '.keyManagement',
@@ -693,7 +693,7 @@ export const IssuersMachine = model.createMachine(
             target: '.tokenRequest',
           },
           PROOF_REQUEST: {
-            actions: ['setCNonce', 'setWellknwonKeyTypes'],
+            actions: ['setCNonce', 'setProofMetadata'],
             target: '.keyManagement',
           },
           CANCEL: {

--- a/machines/Issuers/IssuersMachine.typegen.ts
+++ b/machines/Issuers/IssuersMachine.typegen.ts
@@ -336,7 +336,7 @@ export interface Typegen0 {
       | 'setVCMetadata'
       | 'setVerifiableCredential'
       | 'setVerificationResult'
-      | 'setWellknwonKeyTypes'
+      | 'setProofMetadata'
       | 'storeKeyPair'
       | 'storeVcMetaContext'
       | 'storeVcsContext'
@@ -616,7 +616,7 @@ export interface Typegen0 {
       | 'done.invoke.issuersMachine.downloadCredentials:invocation[0]'
       | 'done.invoke.issuersMachine.proccessingCredential:invocation[0]';
     setVerificationResult: 'done.invoke.issuersMachine.verifyingCredential:invocation[0]';
-    setWellknwonKeyTypes: 'PROOF_REQUEST';
+    setProofMetadata: 'PROOF_REQUEST';
     storeKeyPair:
       | 'done.invoke.issuersMachine.credentialDownloadFromOffer.keyManagement.generateKeyPair:invocation[0]'
       | 'done.invoke.issuersMachine.downloadCredentials.keyManagement.generateKeyPair:invocation[0]';

--- a/machines/Issuers/IssuersModel.test.ts
+++ b/machines/Issuers/IssuersModel.test.ts
@@ -77,8 +77,8 @@ describe('IssuersModel', () => {
       expect(initialContext.keyType).toBe('RS256');
     });
 
-    it('should have wellknownKeyTypes as empty array', () => {
-      expect(initialContext.wellknownKeyTypes).toEqual([]);
+    it('should have jwtProofSigningAlgorithms as empty array', () => {
+      expect(initialContext.jwtProofSigningAlgorithms).toEqual([]);
     });
 
     it('should have authEndpointToOpen as false', () => {
@@ -205,7 +205,7 @@ describe('IssuersModel', () => {
       const arrays = [
         context.issuers,
         context.supportedCredentialTypes,
-        context.wellknownKeyTypes,
+        context.jwtProofSigningAlgorithms,
       ];
 
       arrays.forEach(arr => {

--- a/machines/Issuers/IssuersModel.test.ts
+++ b/machines/Issuers/IssuersModel.test.ts
@@ -153,9 +153,9 @@ describe('IssuersModel', () => {
       expect(initialContext.authorizationSuccess).toBe(false);
     });
 
-    it('should have all 41 required properties', () => {
+    it('should have all 44 required properties', () => {
       const properties = Object.keys(initialContext);
-      expect(properties).toHaveLength(41);
+      expect(properties).toHaveLength(44);
     });
   });
 

--- a/machines/Issuers/IssuersModel.ts
+++ b/machines/Issuers/IssuersModel.ts
@@ -40,7 +40,7 @@ export const IssuersModel = createModel(
     privateKey: '',
     vcMetadata: {} as VCMetadata,
     keyType: 'RS256' as string,
-    wellknownKeyTypes: [] as string[],
+    jwtProofSigningAlgorithms: [] as string[],
     cryptographicBindingMethods: [] as string[],
     proofTypesSupported: [] as string[],
     bindingMethod: DEFAULT_BINDING_METHOD as BindingMethod,

--- a/machines/Issuers/IssuersModel.ts
+++ b/machines/Issuers/IssuersModel.ts
@@ -10,6 +10,10 @@ import {VCMetadata} from '../../shared/VCMetadata';
 import {IssuersEvents} from './IssuersEvents';
 import {issuerType} from './IssuersMachine';
 import {ActorRefFrom} from 'xstate';
+import {
+  BindingMethod,
+  DEFAULT_BINDING_METHOD,
+} from '../../shared/openId4VCI/BindingMethods';
 import {openID4VPMachine} from '../openID4VP/openID4VPMachine';
 import {AuthorizationType} from '../../shared/constants';
 
@@ -37,6 +41,9 @@ export const IssuersModel = createModel(
     vcMetadata: {} as VCMetadata,
     keyType: 'RS256' as string,
     wellknownKeyTypes: [] as string[],
+    cryptographicBindingMethods: [] as string[],
+    proofTypesSupported: [] as string[],
+    bindingMethod: DEFAULT_BINDING_METHOD as BindingMethod,
     authEndpointToOpen: false as boolean,
     isTransactionCodeRequested: false as boolean,
     authEndpoint: '' as string,

--- a/machines/Issuers/IssuersService.test.ts
+++ b/machines/Issuers/IssuersService.test.ts
@@ -30,6 +30,11 @@ jest.mock('../../shared/cryptoutil/cryptoUtil', () => ({
     .mockResolvedValue({publicKey: 'pk', privateKey: 'sk'}),
 }));
 jest.mock('../../shared/openId4VCI/Utils', () => ({
+  // Selection itself is covered in shared/openId4VCI/Utils.test.ts; here we only assert that
+  // getKeyOrderList feeds it the right context and returns what it chose.
+  assertJwtProofTypeSupported: jest.fn(),
+  selectBindingMethod: jest.fn(() => 'jwk'),
+  selectCredentialRequestKey: jest.fn(() => 'ES256'),
   constructProofJWT: jest.fn().mockResolvedValue('proof-jwt'),
   hasKeyPair: jest.fn().mockResolvedValue(true),
   updateCredentialInformation: jest
@@ -318,10 +323,48 @@ describe('IssuersService', () => {
     expect(result).toBe('proof-jwt');
   });
 
-  it('getKeyOrderList returns parsed key order', async () => {
+  it('getKeyOrderList selects the key type and binding method', async () => {
     mockGetData.mockResolvedValueOnce([null, '["ES256"]']);
-    const result = await services.getKeyOrderList();
-    expect(result).toEqual(['ES256']);
+    const result = await services.getKeyOrderList({
+      wellknownKeyTypes: ['ES256'],
+      cryptographicBindingMethods: ['jwk'],
+      proofTypesSupported: ['jwt'],
+    });
+    expect(result).toEqual({
+      keyOrder: ['ES256'],
+      keyType: 'ES256',
+      bindingMethod: 'jwk',
+    });
+  });
+
+  it('getKeyOrderList feeds the issuer metadata into selection', async () => {
+    const Utils = require('../../shared/openId4VCI/Utils');
+    mockGetData.mockResolvedValueOnce([null, '["ES256"]']);
+
+    await services.getKeyOrderList({
+      wellknownKeyTypes: ['ES256'],
+      cryptographicBindingMethods: ['jwk'],
+      proofTypesSupported: ['jwt'],
+    });
+
+    expect(Utils.assertJwtProofTypeSupported).toHaveBeenCalledWith(['jwt']);
+    expect(Utils.selectCredentialRequestKey).toHaveBeenCalledWith(
+      ['ES256'],
+      ['ES256'],
+    );
+    expect(Utils.selectBindingMethod).toHaveBeenCalledWith(['jwk']);
+  });
+
+  it('getKeyOrderList surfaces an unsupported proof type as a failure', async () => {
+    const Utils = require('../../shared/openId4VCI/Utils');
+    mockGetData.mockResolvedValueOnce([null, '["ES256"]']);
+    Utils.assertJwtProofTypeSupported.mockImplementationOnce(() => {
+      throw new Error('Wallet can only produce jwt proofs');
+    });
+
+    await expect(
+      services.getKeyOrderList({proofTypesSupported: ['attestation']}),
+    ).rejects.toThrow(/Wallet can only produce jwt proofs/);
   });
 
   it('getKeyPair returns key pair when it exists', async () => {

--- a/machines/Issuers/IssuersService.test.ts
+++ b/machines/Issuers/IssuersService.test.ts
@@ -298,7 +298,7 @@ describe('IssuersService', () => {
       privateKey: 'sk',
       credentialOfferCredentialIssuer: 'issuer',
       keyType: 'ES256',
-      wellknownKeyTypes: ['ES256'],
+      jwtProofSigningAlgorithms: ['ES256'],
       cNonce: 'nonce1',
     };
     const result = await services.constructProof(context);
@@ -314,7 +314,7 @@ describe('IssuersService', () => {
       privateKey: 'sk',
       selectedIssuer: {credential_issuer_host: 'host', client_id: 'client'},
       keyType: 'ES256',
-      wellknownKeyTypes: ['ES256'],
+      jwtProofSigningAlgorithms: ['ES256'],
       cNonce: 'nonce2',
     };
     const result = await services.constructAndSendProofForTrustedIssuers(
@@ -326,7 +326,7 @@ describe('IssuersService', () => {
   it('getKeyOrderList selects the key type and binding method', async () => {
     mockGetData.mockResolvedValueOnce([null, '["ES256"]']);
     const result = await services.getKeyOrderList({
-      wellknownKeyTypes: ['ES256'],
+      jwtProofSigningAlgorithms: ['ES256'],
       cryptographicBindingMethods: ['jwk'],
       proofTypesSupported: ['jwt'],
     });
@@ -342,7 +342,7 @@ describe('IssuersService', () => {
     mockGetData.mockResolvedValueOnce([null, '["ES256"]']);
 
     await services.getKeyOrderList({
-      wellknownKeyTypes: ['ES256'],
+      jwtProofSigningAlgorithms: ['ES256'],
       cryptographicBindingMethods: ['jwk'],
       proofTypesSupported: ['jwt'],
     });

--- a/machines/Issuers/IssuersService.ts
+++ b/machines/Issuers/IssuersService.ts
@@ -324,7 +324,7 @@ export const IssuersService = () => {
         context.credentialOfferCredentialIssuer,
         null,
         context.keyType,
-        context.wellknownKeyTypes,
+        context.jwtProofSigningAlgorithms,
         context.cNonce,
         context.bindingMethod,
       );
@@ -339,7 +339,7 @@ export const IssuersService = () => {
         context.selectedIssuer.credential_issuer_host,
         context.selectedIssuer.client_id,
         context.keyType,
-        context.wellknownKeyTypes,
+        context.jwtProofSigningAlgorithms,
         context.cNonce,
         context.bindingMethod,
       );
@@ -358,7 +358,7 @@ export const IssuersService = () => {
       return {
         keyOrder,
         keyType: selectCredentialRequestKey(
-          context.wellknownKeyTypes,
+          context.jwtProofSigningAlgorithms,
           keyOrder,
         ),
         bindingMethod: selectBindingMethod(context.cryptographicBindingMethods),

--- a/machines/Issuers/IssuersService.ts
+++ b/machines/Issuers/IssuersService.ts
@@ -7,7 +7,10 @@ import {
   generateKeyPair,
 } from '../../shared/cryptoutil/cryptoUtil';
 import {
+  assertJwtProofTypeSupported,
   constructProofJWT,
+  selectBindingMethod,
+  selectCredentialRequestKey,
   hasKeyPair,
   updateCredentialInformation,
   verifyCredentialData,
@@ -94,12 +97,17 @@ export const IssuersService = () => {
         credentialIssuer: string,
         cNonce: string | null,
         proofSigningAlgosSupported: string[] | null,
+        cryptographicBindingMethodsSupported: string[] | null,
+        proofTypesSupported: string[] | null,
       ) => {
         sendBack({
           type: 'PROOF_REQUEST',
           credentialIssuer: credentialIssuer,
           cNonce: cNonce,
           proofSigningAlgosSupported: proofSigningAlgosSupported,
+          cryptographicBindingMethodsSupported:
+            cryptographicBindingMethodsSupported,
+          proofTypesSupported: proofTypesSupported,
         });
       };
       const getTokenResponse = (tokenRequest: object) => {
@@ -193,12 +201,17 @@ export const IssuersService = () => {
         credentialIssuer: string,
         cNonce: string | null,
         proofSigningAlgosSupported: string[] | null,
+        cryptographicBindingMethodsSupported: string[] | null,
+        proofTypesSupported: string[] | null,
       ) => {
         sendBack({
           type: 'PROOF_REQUEST',
           cNonce: cNonce,
           issuer: credentialIssuer,
           proofSigningAlgosSupported: proofSigningAlgosSupported,
+          cryptographicBindingMethodsSupported:
+            cryptographicBindingMethodsSupported,
+          proofTypesSupported: proofTypesSupported,
         });
       };
 
@@ -313,6 +326,7 @@ export const IssuersService = () => {
         context.keyType,
         context.wellknownKeyTypes,
         context.cNonce,
+        context.bindingMethod,
       );
       await VciClient.getInstance().sendProof(proofJWT);
       return proofJWT;
@@ -327,17 +341,28 @@ export const IssuersService = () => {
         context.keyType,
         context.wellknownKeyTypes,
         context.cNonce,
+        context.bindingMethod,
       );
       await VciClient.getInstance().sendProof(proofJWT);
       return proofJWT;
     },
 
-    getKeyOrderList: async () => {
+    getKeyOrderList: async (context: any) => {
       const {RNSecureKeystoreModule} = NativeModules;
       const keyOrder = JSON.parse(
         (await RNSecureKeystoreModule.getData('keyPreference'))[1],
       );
-      return keyOrder;
+
+      assertJwtProofTypeSupported(context.proofTypesSupported);
+
+      return {
+        keyOrder,
+        keyType: selectCredentialRequestKey(
+          context.wellknownKeyTypes,
+          keyOrder,
+        ),
+        bindingMethod: selectBindingMethod(context.cryptographicBindingMethods),
+      };
     },
 
     generateKeyPair: async (context: any) => {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "base45-web": "^1.0.2",
     "base64url-universal": "^1.1.0",
+    "bs58": "^4.0.1",
     "buffer": "^6.0.3",
     "color-diff": "^1.4.0",
     "date-fns": "2.28.0",

--- a/shared/cryptoutil/didKey.test.ts
+++ b/shared/cryptoutil/didKey.test.ts
@@ -1,0 +1,91 @@
+import bs58 from 'bs58';
+import {Buffer} from 'buffer';
+import {encodeDidKey, didKeyVerificationMethod} from './didKey';
+import {KeyTypes} from './KeyTypes';
+
+const base64url = (bytes: Uint8Array) =>
+  Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+// Published did:key method test vectors. Each is decoded back into the JWK the wallet would
+// derive from its own keystore, so a wrong multicodec prefix or a missing point compression
+// makes the round trip fail.
+const VECTORS = {
+  [KeyTypes.ED25519]:
+    'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
+  [KeyTypes.ES256K]:
+    'did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme',
+  [KeyTypes.ES256]: 'did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169',
+};
+
+const keyBytesOf = (did: string) =>
+  bs58.decode(did.slice('did:key:z'.length)).slice(2);
+
+describe('encodeDidKey', () => {
+  it('encodes an Ed25519 key against the did:key test vector', () => {
+    const raw = keyBytesOf(VECTORS[KeyTypes.ED25519]);
+    const jwk = {kty: 'OKP', crv: 'Ed25519', x: base64url(raw)};
+
+    expect(encodeDidKey(jwk, KeyTypes.ED25519)).toBe(VECTORS[KeyTypes.ED25519]);
+  });
+
+  it.each([
+    [KeyTypes.ES256, 'P-256'],
+    [KeyTypes.ES256K, 'secp256k1'],
+  ])('compresses an %s point to the did:key test vector', (keyType, crv) => {
+    const compressed = keyBytesOf(VECTORS[keyType]);
+    // The vector carries x plus a parity byte. Recovering the real y needs curve arithmetic, and
+    // compression only reads y's parity - so any y with the matching parity exercises the same path.
+    const y = Buffer.alloc(32, 0x11);
+    y[31] = compressed[0] === 0x02 ? 0x02 : 0x03;
+    const jwk = {
+      kty: 'EC',
+      crv,
+      x: base64url(Uint8Array.from(compressed.slice(1))),
+      y: base64url(y),
+    };
+
+    expect(encodeDidKey(jwk, keyType)).toBe(VECTORS[keyType]);
+  });
+
+  it('encodes an RSA key as PKCS#1 DER behind the rsa-pub multicodec', () => {
+    // A 2048-bit modulus. The high bit must be set, as it is for a real RSA key: that is what
+    // makes DER pad the INTEGER and lands the vector on the published z4MXj1wBzi9 prefix.
+    const modulus = Buffer.alloc(256, 0xab);
+    modulus[0] = 0xc7;
+    const jwk = {
+      kty: 'RSA',
+      n: base64url(modulus),
+      e: base64url(Buffer.from([0x01, 0x00, 0x01])),
+    };
+
+    const did = encodeDidKey(jwk, KeyTypes.RS256);
+    const decoded = bs58.decode(did.slice('did:key:z'.length));
+
+    expect(Buffer.from(decoded.slice(0, 2)).toString('hex')).toBe('8524');
+    // PKCS#1 RSAPublicKey is a SEQUENCE of two INTEGERs.
+    expect(decoded[2]).toBe(0x30);
+    expect(did.startsWith('did:key:z4MXj1wBzi9')).toBe(true);
+  });
+
+  it('rejects a key type with no did:key encoding', () => {
+    expect(() => encodeDidKey({}, 'X25519')).toThrow(
+      'did:key encoding is not supported for keyType: X25519',
+    );
+  });
+});
+
+describe('didKeyVerificationMethod', () => {
+  it('repeats the multibase value as the fragment', () => {
+    const raw = keyBytesOf(VECTORS[KeyTypes.ED25519]);
+    const jwk = {kty: 'OKP', crv: 'Ed25519', x: base64url(raw)};
+    const did = VECTORS[KeyTypes.ED25519];
+
+    expect(didKeyVerificationMethod(jwk, KeyTypes.ED25519)).toBe(
+      `${did}#${did.slice('did:key:'.length)}`,
+    );
+  });
+});

--- a/shared/cryptoutil/didKey.ts
+++ b/shared/cryptoutil/didKey.ts
@@ -1,0 +1,95 @@
+import {Buffer} from 'buffer';
+import bs58 from 'bs58';
+import forge from 'node-forge';
+import {KeyTypes} from './KeyTypes';
+
+// Multicodec varint prefixes from the did:key method registry. The raw key bytes that follow
+// differ per type: Ed25519 is the raw 32-byte key, the EC curves use the 33-byte compressed
+// point, and RSA uses the PKCS#1 DER encoding of RSAPublicKey.
+const MULTICODEC_PREFIX: Record<string, number[]> = {
+  [KeyTypes.ED25519]: [0xed, 0x01], // ed25519-pub  0xed
+  [KeyTypes.ES256K]: [0xe7, 0x01], // secp256k1-pub 0xe7
+  [KeyTypes.ES256]: [0x80, 0x24], // p256-pub      0x1200
+  [KeyTypes.RS256]: [0x85, 0x24], // rsa-pub       0x1205
+};
+
+const decodeBase64Url = (value: string): Buffer =>
+  Buffer.from(base64UrlToBase64(value), 'base64');
+
+function base64UrlToBase64(value: string): string {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  return padded + '='.repeat((4 - (padded.length % 4)) % 4);
+}
+
+/**
+ * SEC 1 compressed point: a parity byte for `y` followed by `x`. Both P-256 and secp256k1 use
+ * 32-byte coordinates, so this needs no curve arithmetic - only the parity of the final `y` byte.
+ */
+function compressedEcPoint(jwk: any): Uint8Array {
+  const x = decodeBase64Url(jwk.x);
+  const y = decodeBase64Url(jwk.y);
+  const parity = (y[y.length - 1] & 1) === 0 ? 0x02 : 0x03;
+
+  return Uint8Array.from(Buffer.concat([Buffer.from([parity]), x]));
+}
+
+function pkcs1PublicKeyDer(jwk: any): Uint8Array {
+  const toBigInteger = (value: string) =>
+    new forge.jsbn.BigInteger(decodeBase64Url(value).toString('hex'), 16);
+  const publicKey = forge.pki.setRsaPublicKey(
+    toBigInteger(jwk.n),
+    toBigInteger(jwk.e),
+  );
+  const der = forge.asn1
+    .toDer(forge.pki.publicKeyToRSAPublicKey(publicKey))
+    .getBytes();
+
+  return Uint8Array.from(der, char => char.charCodeAt(0));
+}
+
+function rawPublicKeyBytes(jwk: any, keyType: string): Uint8Array {
+  switch (keyType) {
+    case KeyTypes.ED25519:
+      return Uint8Array.from(decodeBase64Url(jwk.x));
+    case KeyTypes.ES256:
+    case KeyTypes.ES256K:
+      return compressedEcPoint(jwk);
+    case KeyTypes.RS256:
+      return pkcs1PublicKeyDer(jwk);
+    default:
+      throw new Error(
+        `did:key encoding is not supported for keyType: ${keyType}`,
+      );
+  }
+}
+
+/**
+ * Encodes a public key JWK as a did:key identifier - `did:key:z<base58btc(multicodec || key)>`.
+ */
+export function encodeDidKey(publicKeyJwk: any, keyType: string): string {
+  const prefix = MULTICODEC_PREFIX[keyType];
+  if (!prefix) {
+    throw new Error(
+      `did:key encoding is not supported for keyType: ${keyType}`,
+    );
+  }
+
+  const keyBytes = rawPublicKeyBytes(publicKeyJwk, keyType);
+  const multicodec = new Uint8Array(prefix.length + keyBytes.length);
+  multicodec.set(prefix, 0);
+  multicodec.set(keyBytes, prefix.length);
+
+  return `did:key:z${bs58.encode(multicodec)}`;
+}
+
+/**
+ * The verification method id for a did:key, which repeats the multibase value as the fragment.
+ */
+export function didKeyVerificationMethod(
+  publicKeyJwk: any,
+  keyType: string,
+): string {
+  const did = encodeDidKey(publicKeyJwk, keyType);
+
+  return `${did}#${did.slice('did:key:'.length)}`;
+}

--- a/shared/openId4VCI/BindingMethods.ts
+++ b/shared/openId4VCI/BindingMethods.ts
@@ -8,12 +8,19 @@ export enum BindingMethod {
   DID_KEY = 'did:key',
 }
 
+/**
+ * Wallet preference order, most preferred first. `jwk` is first because it is the most widely
+ * accepted and needs no DID resolution on the issuer side.
+ */
 export const WALLET_BINDING_PREFERENCE = [
   BindingMethod.JWK,
   BindingMethod.DID_JWK,
   BindingMethod.DID_KEY,
 ];
 
-export const GENERIC_DID_BINDING_METHOD = 'did';
-
+/**
+ * Used when an issuer advertises no `cryptographic_binding_methods_supported`, or advertises only
+ * methods the wallet cannot produce. This is what the wallet has always sent, so issuers that
+ * omit the field keep working unchanged.
+ */
 export const DEFAULT_BINDING_METHOD = BindingMethod.DID_JWK;

--- a/shared/openId4VCI/BindingMethods.ts
+++ b/shared/openId4VCI/BindingMethods.ts
@@ -1,0 +1,19 @@
+/**
+ * Cryptographic key binding methods the wallet can represent in a holder proof header, as
+ * advertised by an issuer under `cryptographic_binding_methods_supported` (OpenID4VCI 1.0).
+ */
+export enum BindingMethod {
+  JWK = 'jwk',
+  DID_JWK = 'did:jwk',
+  DID_KEY = 'did:key',
+}
+
+export const WALLET_BINDING_PREFERENCE = [
+  BindingMethod.JWK,
+  BindingMethod.DID_JWK,
+  BindingMethod.DID_KEY,
+];
+
+export const GENERIC_DID_BINDING_METHOD = 'did';
+
+export const DEFAULT_BINDING_METHOD = BindingMethod.DID_JWK;

--- a/shared/openId4VCI/Utils.test.ts
+++ b/shared/openId4VCI/Utils.test.ts
@@ -692,10 +692,6 @@ describe('openId4VCI Utils', () => {
       );
     });
 
-    it('treats a generic did as any supported did method', () => {
-      expect(selectBindingMethod(['did'])).toBe(BindingMethod.DID_JWK);
-    });
-
     it('falls back to did:jwk when the issuer advertises nothing', () => {
       expect(selectBindingMethod([])).toBe(BindingMethod.DID_JWK);
       expect(selectBindingMethod(undefined as any)).toBe(BindingMethod.DID_JWK);

--- a/shared/openId4VCI/Utils.test.ts
+++ b/shared/openId4VCI/Utils.test.ts
@@ -8,6 +8,10 @@ import {
   getDisplayObjectForCurrentLanguage,
   removeBottomSectionFields,
   getMatchingCredentialIssuerMetadata,
+  assertJwtProofTypeSupported,
+  buildProofHeader,
+  getJwtProofSigningAlgorithms,
+  selectBindingMethod,
   selectCredentialRequestKey,
   updateCredentialInformation,
   getVcVerificationDetails,
@@ -23,6 +27,7 @@ import {
   getDetailedViewFields,
 } from './Utils';
 import {VCFormat} from '../VCFormat';
+import {BindingMethod} from './BindingMethods';
 
 // Mock VCProcessor
 jest.mock('../../components/VC/common/VCProcessor', () => ({
@@ -668,6 +673,126 @@ describe('openId4VCI Utils', () => {
         VCFormat.ldp_vc,
       );
       expect(result).toEqual({isVerified: true});
+    });
+  });
+
+  describe('selectBindingMethod', () => {
+    it.each([
+      [['jwk'], BindingMethod.JWK],
+      [['did:jwk'], BindingMethod.DID_JWK],
+      [['did:key'], BindingMethod.DID_KEY],
+    ])('picks %s advertised by the issuer', (advertised, expected) => {
+      expect(selectBindingMethod(advertised)).toBe(expected);
+    });
+
+    it('prefers the wallet order over the issuer order', () => {
+      expect(selectBindingMethod(['did:key', 'jwk'])).toBe(BindingMethod.JWK);
+      expect(selectBindingMethod(['did:key', 'did:jwk'])).toBe(
+        BindingMethod.DID_JWK,
+      );
+    });
+
+    it('treats a generic did as any supported did method', () => {
+      expect(selectBindingMethod(['did'])).toBe(BindingMethod.DID_JWK);
+    });
+
+    it('falls back to did:jwk when the issuer advertises nothing', () => {
+      expect(selectBindingMethod([])).toBe(BindingMethod.DID_JWK);
+      expect(selectBindingMethod(undefined as any)).toBe(BindingMethod.DID_JWK);
+    });
+
+    it('falls back to did:jwk when no advertised method is supported', () => {
+      expect(selectBindingMethod(['cose_key', 'x5c'])).toBe(
+        BindingMethod.DID_JWK,
+      );
+    });
+  });
+
+  describe('getJwtProofSigningAlgorithms', () => {
+    it('reads the jwt proof signing algorithms', () => {
+      expect(
+        getJwtProofSigningAlgorithms({
+          proof_types_supported: {
+            jwt: {proof_signing_alg_values_supported: ['ES256', 'RS256']},
+          },
+        }),
+      ).toEqual(['ES256', 'RS256']);
+    });
+
+    it('returns an empty list when proof types are absent', () => {
+      expect(getJwtProofSigningAlgorithms({})).toEqual([]);
+      expect(getJwtProofSigningAlgorithms(undefined)).toEqual([]);
+    });
+  });
+
+  describe('assertJwtProofTypeSupported', () => {
+    it('accepts a configuration advertising jwt', () => {
+      expect(() =>
+        assertJwtProofTypeSupported(['jwt', 'attestation']),
+      ).not.toThrow();
+    });
+
+    it('accepts a configuration advertising nothing', () => {
+      expect(() => assertJwtProofTypeSupported([])).not.toThrow();
+      expect(() => assertJwtProofTypeSupported(undefined)).not.toThrow();
+    });
+
+    it('rejects a configuration that supports no jwt proof type', () => {
+      expect(() => assertJwtProofTypeSupported(['attestation'])).toThrow(
+        /Wallet can only produce jwt proofs/,
+      );
+    });
+  });
+
+  describe('buildProofHeader', () => {
+    const jwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: 'FSBGSlM8OT4tS3xEKGdW0kU-fVeaVfXcAOZgLBnpMWg',
+    };
+
+    it('carries a raw jwk and no kid for the jwk binding', () => {
+      const header = buildProofHeader(
+        jwk,
+        'EdDSA',
+        BindingMethod.JWK,
+        'Ed25519',
+      );
+
+      expect(header).toEqual({alg: 'EdDSA', typ: 'openid4vci-proof+jwt', jwk});
+      expect(header.kid).toBeUndefined();
+    });
+
+    it('carries a did:jwk kid and no jwk for the did:jwk binding', () => {
+      const header = buildProofHeader(
+        jwk,
+        'EdDSA',
+        BindingMethod.DID_JWK,
+        'Ed25519',
+      );
+
+      expect(header.jwk).toBeUndefined();
+      expect(header.kid).toMatch(/^did:jwk:.+#0$/);
+    });
+
+    it('carries a did:key kid for the did:key binding', () => {
+      const header = buildProofHeader(
+        jwk,
+        'EdDSA',
+        BindingMethod.DID_KEY,
+        'Ed25519',
+      );
+
+      expect(header.jwk).toBeUndefined();
+      expect(header.kid).toMatch(
+        /^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]+#z6Mk[1-9A-HJ-NP-Za-km-z]+$/,
+      );
+    });
+
+    it('rejects an unknown binding method', () => {
+      expect(() =>
+        buildProofHeader(jwk, 'EdDSA', 'cose_key' as any, 'Ed25519'),
+      ).toThrow('Unsupported binding method: cose_key');
     });
   });
 

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -30,6 +30,13 @@ import {getVerifiableCredential} from '../../machines/VerifiableCredential/VCIte
 import {getErrorEventData, sendErrorEvent} from '../telemetry/TelemetryUtils';
 import {TelemetryConstants} from '../telemetry/TelemetryConstants';
 import {KeyTypes} from '../cryptoutil/KeyTypes';
+import {didKeyVerificationMethod} from '../cryptoutil/didKey';
+import {
+  BindingMethod,
+  DEFAULT_BINDING_METHOD,
+  GENERIC_DID_BINDING_METHOD,
+  WALLET_BINDING_PREFERENCE,
+} from './BindingMethods';
 import {VCFormat} from '../VCFormat';
 import {UnsupportedVcFormat} from '../error/UnsupportedVCFormat';
 import {VCMetadata} from '../VCMetadata';
@@ -532,6 +539,30 @@ export const ErrorLogMessages: Record<VCIServerErrorCode, string> = {
     'Unknown error occurred during credential issuance flow.',
 };
 
+/**
+ * Builds the proof JWT header for the selected binding method. OpenID4VCI requires exactly one
+ * of `jwk` or `kid`, so the `jwk` binding must not also carry a `kid`.
+ */
+export function buildProofHeader(
+  jwk: any,
+  alg: string,
+  bindingMethod: BindingMethod,
+  keyType: string,
+): Record<string, any> {
+  const header: Record<string, any> = {alg, typ: 'openid4vci-proof+jwt'};
+
+  switch (bindingMethod) {
+    case BindingMethod.JWK:
+      return {...header, jwk};
+    case BindingMethod.DID_JWK:
+      return {...header, kid: `did:jwk:${base64url(JSON.stringify(jwk))}#0`};
+    case BindingMethod.DID_KEY:
+      return {...header, kid: didKeyVerificationMethod(jwk, keyType)};
+    default:
+      throw new Error(`Unsupported binding method: ${bindingMethod}`);
+  }
+}
+
 export async function constructProofJWT(
   publicKey: any,
   privateKey: any,
@@ -540,6 +571,7 @@ export async function constructProofJWT(
   keyType: string,
   proofSigningAlgosSupported: string[] = [],
   cNonce?: string,
+  bindingMethod: BindingMethod = DEFAULT_BINDING_METHOD,
 ): Promise<string> {
   const jwk = await getJWK(publicKey, keyType);
   const nonce = cNonce;
@@ -556,11 +588,7 @@ export async function constructProofJWT(
     throw new Error(`Failed to construct JWK for keyType: ${keyType}`);
   }
 
-  const jwtHeader: Record<string, any> = {
-    alg,
-    typ: 'openid4vci-proof+jwt',
-    kid: `did:jwk:${base64url(JSON.stringify(jwk))}#0`,
-  };
+  const jwtHeader = buildProofHeader(jwk, alg, bindingMethod, keyType);
   const jwtPayload = {
     ...(client_id ? {iss: client_id} : {}),
     nonce,
@@ -654,6 +682,42 @@ export async function hasKeyPair(keyType: any): Promise<boolean> {
     console.error('key not found');
     return false;
   }
+}
+
+export function getJwtProofSigningAlgorithms(credentialType: any): string[] {
+  const proofTypesSupported = credentialType?.proof_types_supported;
+
+  return (proofTypesSupported?.jwt?.proof_signing_alg_values_supported ??
+    []) as string[];
+}
+
+export function assertJwtProofTypeSupported(
+  proofTypesSupported: string[] = [],
+) {
+  if (proofTypesSupported?.length && !proofTypesSupported.includes('jwt')) {
+    throw new Error(
+      `Wallet can only produce jwt proofs - issuer supports [${proofTypesSupported}]`,
+    );
+  }
+}
+
+export function selectBindingMethod(
+  cryptographicBindingMethodsSupported: string[] = [],
+): BindingMethod {
+  if (!cryptographicBindingMethodsSupported?.length) {
+    return DEFAULT_BINDING_METHOD;
+  }
+
+  const advertised = new Set(cryptographicBindingMethodsSupported);
+  const supportsGenericDid = advertised.has(GENERIC_DID_BINDING_METHOD);
+
+  return (
+    WALLET_BINDING_PREFERENCE.find(
+      bindingMethod =>
+        advertised.has(bindingMethod) ||
+        (supportsGenericDid && bindingMethod.startsWith('did:')),
+    ) ?? DEFAULT_BINDING_METHOD
+  );
 }
 
 export function selectCredentialRequestKey(

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -34,7 +34,6 @@ import {didKeyVerificationMethod} from '../cryptoutil/didKey';
 import {
   BindingMethod,
   DEFAULT_BINDING_METHOD,
-  GENERIC_DID_BINDING_METHOD,
   WALLET_BINDING_PREFERENCE,
 } from './BindingMethods';
 import {VCFormat} from '../VCFormat';
@@ -709,13 +708,10 @@ export function selectBindingMethod(
   }
 
   const advertised = new Set(cryptographicBindingMethodsSupported);
-  const supportsGenericDid = advertised.has(GENERIC_DID_BINDING_METHOD);
 
   return (
-    WALLET_BINDING_PREFERENCE.find(
-      bindingMethod =>
-        advertised.has(bindingMethod) ||
-        (supportsGenericDid && bindingMethod.startsWith('did:')),
+    WALLET_BINDING_PREFERENCE.find(bindingMethod =>
+      advertised.has(bindingMethod),
     ) ?? DEFAULT_BINDING_METHOD
   );
 }

--- a/shared/vciClient/VciClient.test.ts
+++ b/shared/vciClient/VciClient.test.ts
@@ -317,8 +317,16 @@ describe('VciClient', () => {
         credentialIssuer: 'iss',
         cNonce: 'nonce',
         proofSigningAlgorithmsSupported: '["ES256"]',
+        cryptographicBindingMethodsSupported: '["jwk"]',
+        proofTypesSupported: '["jwt"]',
       });
-      expect(getProofJwt).toHaveBeenCalledWith('iss', 'nonce', ['ES256']);
+      expect(getProofJwt).toHaveBeenCalledWith(
+        'iss',
+        'nonce',
+        ['ES256'],
+        ['jwk'],
+        ['jwt'],
+      );
 
       expect(listenerMap['onRequestAuthCode']).toBeDefined();
       listenerMap['onRequestAuthCode']({

--- a/shared/vciClient/VciClient.ts
+++ b/shared/vciClient/VciClient.ts
@@ -100,6 +100,8 @@ class VciClient {
       credentialIssuer: string,
       cNonce: string | null,
       proofSigningAlgosSupported: string[] | null,
+      cryptographicBindingMethodsSupported: string[] | null,
+      proofTypesSupported: string[] | null,
     ) => void,
     navigateToAuthView: (authorizationEndpoint: string) => void,
     requestTokenResponse: (tokenRequest: object) => void,
@@ -112,11 +114,19 @@ class VciClient {
   ): Promise<any> {
     const proofListener = emitter.addListener(
       'onRequestProof',
-      ({credentialIssuer, cNonce, proofSigningAlgorithmsSupported}) => {
+      ({
+        credentialIssuer,
+        cNonce,
+        proofSigningAlgorithmsSupported,
+        cryptographicBindingMethodsSupported,
+        proofTypesSupported,
+      }) => {
         getProofJwt(
           credentialIssuer,
           cNonce,
           JSON.parse(proofSigningAlgorithmsSupported),
+          JSON.parse(cryptographicBindingMethodsSupported ?? '[]'),
+          JSON.parse(proofTypesSupported ?? '[]'),
         );
       },
     );
@@ -214,6 +224,8 @@ class VciClient {
       credentialIssuer: string,
       cNonce: string | null,
       proofSigningAlgosSupported: string[] | null,
+      cryptographicBindingMethodsSupported: string[] | null,
+      proofTypesSupported: string[] | null,
     ) => void,
     navigateToAuthView: (authorizationEndpoint: string) => void,
     requestTokenResponse: (tokenRequest: object) => void,
@@ -222,11 +234,19 @@ class VciClient {
   ): Promise<any> {
     const proofListener = emitter.addListener(
       'onRequestProof',
-      ({credentialIssuer, cNonce, proofSigningAlgorithmsSupported}) => {
+      ({
+        credentialIssuer,
+        cNonce,
+        proofSigningAlgorithmsSupported,
+        cryptographicBindingMethodsSupported,
+        proofTypesSupported,
+      }) => {
         getProofJwt(
           credentialIssuer,
           cNonce,
           JSON.parse(proofSigningAlgorithmsSupported),
+          JSON.parse(cryptographicBindingMethodsSupported ?? '[]'),
+          JSON.parse(proofTypesSupported ?? '[]'),
         );
       },
     );


### PR DESCRIPTION
Resolves #2583

Reads `cryptographic_binding_methods_supported` from the issuer's well-known and emits the matching binding in the holder proof header — `jwk`, `did:jwk` or `did:key` — instead of always sending a `did:jwk` kid. Falls back to `did:jwk` when the issuer advertises nothing, or nothing the wallet supports.

Depends on inji/inji-vci-client#168 and inji/inji-vci-client-ios-swift#120; the vci-client dependency version will be updated once those are merged and published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for issuer-provided proof metadata, including supported proof types, signing algorithms, and cryptographic binding methods.
  * Added automatic selection of compatible wallet binding methods, including JWK, `did:jwk`, and `did:key`.
  * Added `did:key` generation for supported Ed25519, EC, and RSA credentials.
* **Bug Fixes**
  * Improved proof requests to validate supported JWT proof types and use the issuer’s advertised capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->