### PR TITLE
fix(vcjs): Ed25519 VC verification compatibility for DID and legacy flows

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -9,7 +9,7 @@ fileignoreconfig:
 - filename: package.json
   checksum: 5b4fcb5ddc7cc96cc2d1733b544d56ea66e88cdab995a1052fbf9ac0e9c2dc21
 - filename: lib/jsonld-signatures/suites/ed255192018/ed25519.ts
-  checksum: 493b6e31144116cb612c24d98b97d8adcad5609c0a52c865a6847ced0a0ddc3a
+  checksum: c6027a62b944af457032008395c17ef08865c43124a3b99e7ef64d85eb79cc0a
 - filename: i18n.ts
   checksum: e80d40f33692c195d034774d024cafdf63d010ac6d4a35f94b2a5d81b78c234b
 - filename: components/Passcode.tsx

--- a/lib/jsonld-signatures/suites/ed255192018/ed25519.ts
+++ b/lib/jsonld-signatures/suites/ed255192018/ed25519.ts
@@ -3,22 +3,14 @@
  */
 import {Buffer} from 'buffer';
 
-import forge, {pki, asn1, util, random, md} from 'node-forge';
+import forge, {pki, asn1, random} from 'node-forge';
 
 type PrivateKey = forge.pki.PrivateKey;
 type PublicKey = forge.pki.PublicKey;
 
-const {
-  publicKeyToAsn1,
-  publicKeyFromAsn1,
-  privateKeyToAsn1,
-  privateKeyFromAsn1,
-  ed25519,
-} = pki;
+const {publicKeyToAsn1, privateKeyToAsn1, privateKeyFromAsn1, ed25519} = pki;
 const {toDer, fromDer: forgeFromDer} = asn1;
-const {createBuffer} = util;
 const {getBytesSync: getRandomBytes} = random;
-const {sha256} = md;
 
 // used to export node's public keys to buffers
 const publicKeyEncoding = {format: 'der', type: 'spki'};
@@ -63,17 +55,19 @@ const api = {
     return api.generateKeyPairFromSeed(seed);
   },
   async sign(privateKeyBytes, data) {
-    const privateKey: PrivateKey = forgePrivateKey(
-      _privateKeyDerEncode({privateKeyBytes}),
-    );
-    const signature: string = forgeSign(data, privateKey);
+    const privateKey = Uint8Array.from(privateKeyBytes);
+    const message = Buffer.from(data, 'utf8');
 
-    return signature;
+    const signature = ed25519.sign({
+      privateKey,
+      message,
+    });
+
+    return Buffer.from(signature).toString('binary');
   },
   async verify(publicKeyBytes: Uint8Array, data: string, signature: string) {
-    const publicKey = await createForgePublicKeyFromPublicKeyBuffer(
-      _publicKeyDerEncode({publicKeyBytes}),
-    );
+    const publicKey = createForgePublicKeyFromPublicKeyBuffer(publicKeyBytes);
+
     return forgeVerifyEd25519(data, publicKey, signature);
   },
 };
@@ -98,38 +92,30 @@ function createForgePublicKeyFromPrivateKeyBuffer(
   return publicKey;
 }
 
+/**
+ * Validates that the public key is a raw 32-byte Uint8Array/Buffer.
+ */
 function createForgePublicKeyFromPublicKeyBuffer(
-  publicKeyBuffer: Buffer,
-): string {
-  const publicKeyObject = publicKeyFromAsn1(fromDer(publicKeyBuffer));
-  const publicKeyDer = toDer(publicKeyToAsn1(publicKeyObject)).getBytes();
+  publicKeyBuffer: Uint8Array,
+): Uint8Array {
+  if (publicKeyBuffer.length !== 32) {
+    throw new Error(
+      `Invalid Ed25519 public key length: expected 32 bytes, got ${publicKeyBuffer.length}`,
+    );
+  }
 
-  return publicKeyDer;
-}
-
-function forgeSign(data: string, privateKeyObject: PrivateKey): string {
-  const privateKeyBytes = toDer(privateKeyToAsn1(privateKeyObject)).getBytes();
-
-  const privateKey = createBuffer(privateKeyBytes);
-
-  const signature = ed25519.sign({
-    privateKey,
-    md: sha256.create(),
-    message: data,
-  });
-
-  return signature.toString('binary');
+  return publicKeyBuffer;
 }
 
 function forgeVerifyEd25519(
   data: string,
-  publicKey: string,
+  publicKey: Uint8Array,
   signature: string,
 ): boolean {
   return ed25519.verify({
-    publicKey: publicKey,
-    signature: createBuffer(signature),
-    message: createBuffer(data),
+    publicKey,
+    signature: Buffer.from(signature, 'binary'),
+    message: Buffer.from(data, 'utf8'),
   });
 }
 

--- a/shared/vcjs/DocumentLoader.test.ts
+++ b/shared/vcjs/DocumentLoader.test.ts
@@ -1,0 +1,205 @@
+const mockLoader = jest.fn();
+
+jest.mock('@digitalcredentials/jsonld', () => ({
+  documentLoaders: {
+    xhr: jest.fn(() => mockLoader),
+  },
+}));
+
+const {DocumentLoader} = require('./DocumentLoader');
+
+describe('DocumentLoader', () => {
+  beforeEach(() => {
+    mockLoader.mockReset();
+  });
+
+  describe('httpsLoader', () => {
+    it('should parse string document into object', async () => {
+      mockLoader.mockResolvedValue({
+        document: '{"id":"did:web:example.com"}',
+      });
+
+      const result = await (DocumentLoader as any).httpsLoader(
+        'https://example.com/did.json',
+      );
+
+      expect(result.document).toEqual({
+        id: 'did:web:example.com',
+      });
+    });
+
+    it('should throw when document is not a string or object', async () => {
+      mockLoader.mockResolvedValue({
+        document: 123,
+      });
+
+      await expect(
+        (DocumentLoader as any).httpsLoader('https://example.com/did.json'),
+      ).rejects.toThrow(
+        'Unsupported document type for https://example.com/did.json: number',
+      );
+    });
+
+    it('should throw when document contains invalid JSON', async () => {
+      mockLoader.mockResolvedValue({
+        document: '{invalid json}',
+      });
+
+      await expect(
+        (DocumentLoader as any).httpsLoader('https://example.com/did.json'),
+      ).rejects.toThrow(
+        'Failed to parse JSON document from https://example.com/did.json',
+      );
+    });
+  });
+
+  describe('didWebDocumentLoader', () => {
+    it('should resolve root did:web DID', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:example.com',
+        },
+      });
+
+      const result = await DocumentLoader.didWebDocumentLoader(
+        'did:web:example.com',
+      );
+
+      expect(mockLoader).toHaveBeenCalledWith(
+        'https://example.com/.well-known/did.json',
+      );
+
+      expect(result.document).toEqual({
+        id: 'did:web:example.com',
+      });
+
+      expect(result.documentUrl).toBe('did:web:example.com');
+    });
+
+    it('should resolve did:web with path', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:example.com:user',
+        },
+      });
+
+      await DocumentLoader.didWebDocumentLoader('did:web:example.com:user');
+
+      expect(mockLoader).toHaveBeenCalledWith(
+        'https://example.com/user/did.json',
+      );
+    });
+
+    it('should resolve did:web DID with a port', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:localhost%3A8080',
+        },
+      });
+
+      await DocumentLoader.didWebDocumentLoader('did:web:localhost%3A8080');
+
+      expect(mockLoader).toHaveBeenCalledWith(
+        'https://localhost:8080/.well-known/did.json',
+      );
+    });
+
+    it('should throw when resolved DID document id does not match requested DID', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:different.com',
+        },
+      });
+
+      await expect(
+        DocumentLoader.didWebDocumentLoader('did:web:example.com'),
+      ).rejects.toThrow(
+        'Resolved DID document id does not match did:web:example.com',
+      );
+    });
+
+    it('should ignore fragment while resolving DID', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:example.com',
+        },
+      });
+
+      const result = await DocumentLoader.didWebDocumentLoader(
+        'did:web:example.com#key-1',
+      );
+
+      expect(mockLoader).toHaveBeenCalledWith(
+        'https://example.com/.well-known/did.json',
+      );
+
+      expect(result.documentUrl).toBe('did:web:example.com#key-1');
+    });
+
+    it('should ignore query while resolving DID', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:example.com',
+        },
+      });
+
+      await DocumentLoader.didWebDocumentLoader('did:web:example.com?foo=bar');
+
+      expect(mockLoader).toHaveBeenCalledWith(
+        'https://example.com/.well-known/did.json',
+      );
+    });
+
+    it('should load a plain https URL', async () => {
+      mockLoader.mockResolvedValue({
+        document: {
+          id: 'did:web:example.com',
+        },
+      });
+
+      const result = await DocumentLoader.didWebDocumentLoader(
+        'https://example.com/did.json',
+      );
+
+      expect(mockLoader).toHaveBeenCalledWith('https://example.com/did.json');
+
+      expect(result.document).toEqual({
+        id: 'did:web:example.com',
+      });
+    });
+
+    it('should throw for malformed did:web URL', async () => {
+      await expect(
+        DocumentLoader.didWebDocumentLoader('did:web:'),
+      ).rejects.toThrow('Invalid did:web URL: did:web:');
+    });
+
+    it('should throw when did:web URL has an empty domain', async () => {
+      await expect(
+        DocumentLoader.didWebDocumentLoader('did:web::user'),
+      ).rejects.toThrow('Invalid did:web URL: missing domain in did:web::user');
+    });
+
+    it('should reject http URLs', async () => {
+      await expect(
+        DocumentLoader.didWebDocumentLoader('http://example.com/did.json'),
+      ).rejects.toThrow('Unsupported URL: http://example.com/did.json');
+
+      expect(mockLoader).not.toHaveBeenCalled();
+    });
+
+    it('should propagate loader errors', async () => {
+      mockLoader.mockRejectedValue(new Error('network error'));
+
+      await expect(
+        DocumentLoader.didWebDocumentLoader('did:web:example.com'),
+      ).rejects.toThrow('network error');
+    });
+
+    it('should throw for unsupported URL scheme', async () => {
+      await expect(
+        DocumentLoader.didWebDocumentLoader('ftp://example.com'),
+      ).rejects.toThrow('Unsupported URL: ftp://example.com');
+    });
+  });
+});

--- a/shared/vcjs/DocumentLoader.ts
+++ b/shared/vcjs/DocumentLoader.ts
@@ -1,0 +1,100 @@
+import jsonld from '@digitalcredentials/jsonld';
+
+export class DocumentLoader {
+  private static defaultLoader: ReturnType<
+    typeof jsonld.documentLoaders.xhr
+  > | null = null;
+
+  private static getDefaultLoader() {
+    if (!DocumentLoader.defaultLoader) {
+      DocumentLoader.defaultLoader = jsonld.documentLoaders.xhr();
+    }
+
+    return DocumentLoader.defaultLoader;
+  }
+
+  private static async httpsLoader(url: string) {
+    console.info('[HTTPS_LOADER] Fetching:', url);
+
+    const result = await DocumentLoader.getDefaultLoader()(url);
+
+    if (typeof result.document === 'string') {
+      try {
+        result.document = JSON.parse(result.document);
+      } catch (error) {
+        throw new Error(
+          `Failed to parse JSON document from ${url}: ${String(error)}`,
+        );
+      }
+    } else if (
+      typeof result.document !== 'object' ||
+      result.document === null
+    ) {
+      throw new Error(
+        `Unsupported document type for ${url}: ${typeof result.document}`,
+      );
+    }
+
+    console.info('[HTTPS_LOADER] Success:', url);
+
+    return result;
+  }
+
+  static async didWebDocumentLoader(url: string) {
+    console.info('[DOC_LOADER] Request:', url);
+
+    if (url.startsWith('https://')) {
+      return DocumentLoader.httpsLoader(url);
+    }
+
+    if (url.startsWith('did:web:')) {
+      const didWithoutFragmentAndQuery = url.split(/[?#]/)[0];
+      const did = didWithoutFragmentAndQuery.replace('did:web:', '');
+
+      if (!did) {
+        throw new Error(`Invalid did:web URL: ${url}`);
+      }
+
+      const components = did.split(':').map(decodeURIComponent);
+      const baseDomain = components[0];
+
+      if (!baseDomain) {
+        throw new Error(`Invalid did:web URL: missing domain in ${url}`);
+      }
+
+      const path = components.slice(1).join('/');
+      const didUrl =
+        path.length === 0
+          ? `https://${baseDomain}/.well-known/did.json`
+          : `https://${baseDomain}/${path}/did.json`;
+
+      console.info('[DOC_LOADER] Resolving DID:', didUrl);
+
+      try {
+        const response = await DocumentLoader.httpsLoader(didUrl);
+
+        if (response.document.id !== didWithoutFragmentAndQuery) {
+          throw new Error(
+            `Resolved DID document id does not match ${didWithoutFragmentAndQuery}`,
+          );
+        }
+
+        console.info(
+          'DID_DOCUMENT',
+          JSON.stringify(response.document, null, 2),
+        );
+
+        response.documentUrl = url;
+
+        console.info('[DOC_LOADER] DID resolved successfully');
+
+        return response;
+      } catch (error) {
+        console.error('[DOC_LOADER] DID resolution failed:', error);
+        throw error;
+      }
+    }
+
+    throw new Error(`Unsupported URL: ${url}`);
+  }
+}

--- a/shared/vcjs/verifyCredential.test.ts
+++ b/shared/vcjs/verifyCredential.test.ts
@@ -299,6 +299,39 @@ describe('shared/vcjs/verifyCredential', () => {
       expect(result.isVerified).toBe(true);
     });
 
+    it('should use DocumentLoader.didWebDocumentLoader with vcjs', async () => {
+      const {isIOS, isAndroid} = require('../constants');
+      isAndroid.mockReturnValue(false);
+      isIOS.mockReturnValue(true);
+
+      const vcjs = require('@digitalcredentials/vc');
+      vcjs.verifyCredential.mockResolvedValueOnce({
+        verified: true,
+      });
+
+      const documentLoader = require('./DocumentLoader');
+
+      const {verifyCredential} = require('./verifyCredential');
+
+      await verifyCredential(
+        {
+          proof: {
+            type: 'RsaSignature2018',
+            proofPurpose: 'assertionMethod',
+            verificationMethod: 'key1',
+            created: '2024-01-01',
+          },
+        },
+        'ldp_vc',
+      );
+
+      expect(vcjs.verifyCredential).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentLoader: documentLoader.DocumentLoader.didWebDocumentLoader,
+        }),
+      );
+    });
+
     it('handles failed vcjs verification on iOS with InvalidUrl', async () => {
       const {isIOS, isAndroid} = require('../constants');
       isAndroid.mockReturnValue(false);

--- a/shared/vcjs/verifyCredential.ts
+++ b/shared/vcjs/verifyCredential.ts
@@ -1,9 +1,9 @@
-import jsonld from '@digitalcredentials/jsonld';
 import vcjs from '@digitalcredentials/vc';
 import {RsaSignature2018} from '../../lib/jsonld-signatures/suites/rsa2018/RsaSignature2018';
 import {Ed25519Signature2018} from '../../lib/jsonld-signatures/suites/ed255192018/Ed25519Signature2018';
 import {AssertionProofPurpose} from '../../lib/jsonld-signatures/purposes/AssertionProofPurpose';
 import {PublicKeyProofPurpose} from '../../lib/jsonld-signatures/purposes/PublicKeyProofPurpose';
+import {DocumentLoader} from './DocumentLoader';
 import {
   Credential,
   VerifiableCredential,
@@ -20,7 +20,6 @@ import VCVerifier, {
   RevocationStatusType,
   VerificationSummaryResult,
 } from '../vcVerifier/VcVerifier';
-
 // FIXME: Ed25519Signature2018 not fully supported yet.
 // Ed25519Signature2018 proof type check is not tested with its real credential
 const ProofType = {
@@ -102,9 +101,8 @@ async function verifyCredentialForIos(
       purpose,
       suite,
       credential: verifiableCredential,
-      documentLoader: jsonld.documentLoaders.xhr(),
+      documentLoader: DocumentLoader.didWebDocumentLoader,
     };
-
     const result = await vcjs.verifyCredential(vcjsOptions);
     verificationResponse = handleResponse(result, verifiableCredential);
   }


### PR DESCRIPTION
Summary:
- Add a did:web aware document loader (`shared/vcjs/DocumentLoader.ts`) with unit tests.
- Align the Ed25519 2018 suite so VC verification works for both DID-based and legacy VC download flows.


Authored by @bhanupratap632004-code; opened here from the technocratblues fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added document loading for HTTPS URLs and `did:web` identifiers during credential verification.
  - Added validation for document formats, DID identities, URL support, and malformed responses.
  - Updated iOS credential verification to use the new document loader.
  - Improved Ed25519 signing and verification compatibility with raw key bytes.

- **Tests**
  - Added coverage for document loading, URL resolution, error handling, and iOS credential verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->